### PR TITLE
Python Syntax Highlight Improvement

### DIFF
--- a/ninja_ide/addins/syntax/python.json
+++ b/ninja_ide/addins/syntax/python.json
@@ -63,6 +63,7 @@
     "import", 
     "in", 
     "is", 
+    "as",
     "lambda", 
     "not", 
     "or", 


### PR DESCRIPTION
Added "as" as reserved word in Python Syntax Highlight

Signed-off-by: Wagner Barongello wagner@barongello.com.br
