### PR TITLE
Changed Behavious when Indent set to 0

### DIFF
--- a/ninja_ide/gui/editor/editor.py
+++ b/ninja_ide/gui/editor/editor.py
@@ -452,16 +452,23 @@ class Editor(QPlainTextEdit, itab_item.ITabItem):
         elif settings.ALLOW_TABS_NON_PYTHON and self.lang != 'python':
             return False
         else:
-            self.textCursor().insertText(' ' * settings.INDENT)
+            if not settings.INDENT:
+			    self.textCursor().insertText('\t')
+            else:		
+                self.textCursor().insertText(' ' * settings.INDENT)
         return True
 
     def __backspace(self, event):
         if self.textCursor().hasSelection():
             return False
-        for i in xrange(settings.INDENT):
+        if not settings.INDENT:
+            indent = 1
+        else:
+		    indent = settings.INDENT
+        for i in xrange(indent):
             self.moveCursor(QTextCursor.Left, QTextCursor.KeepAnchor)
         text = self.textCursor().selection()
-        if unicode(text.toPlainText()) == ' ' * settings.INDENT:
+        if unicode(text.toPlainText()) == ' ' * indent:
             self.textCursor().removeSelectedText()
             return True
         else:


### PR DESCRIPTION
Changed the behaviour of the Ninja-IDE, in case the indent is set to 0 in the program settings, use Tabs instead of Spaces. Since I've noticed that setting indent to 0 prevent the Tab button and Backspace one from working correctly. Changed file: gut/editor -- Metods: __insert_indentation() and __backspace()
