### PR TITLE
Fixing performance issue

### DIFF
--- a/ninja_ide/gui/editor/editor.py
+++ b/ninja_ide/gui/editor/editor.py
@@ -1013,7 +1013,7 @@ class Editor(QPlainTextEdit, itab_item.ITabItem):
         if not self.isReadOnly() and not self.textCursor().hasSelection():
             word = self._text_under_cursor()
             self.wordSelection = []
-            if self._patIsWord.match(word):
+            if len(word) > 2 and self._patIsWord.match(word):
                 lineColor = QColor(
                     resources.CUSTOM_SCHEME.get('selected-word',
                         resources.COLOR_SCHEME['selected-word']))


### PR DESCRIPTION
I changed the highlight of the current word to have at least 3 characters, because this highlighting persist during the movement of the cursor and when you say (maybe by mistake) to highlight for example 1 characters in particular, the editor need to highlight the occurrence of that char in the whole document and that is unnecessary slow, highlighting just one char doesn't have any sense.
