### PR TITLE
Fixes to issues when closing tabs with split window

### DIFF
--- a/ninja_ide/gui/main_panel/main_container.py
+++ b/ninja_ide/gui/main_panel/main_container.py
@@ -161,6 +161,7 @@ class __MainContainer(QSplitter):
             self.show_split(Qt.Vertical)
 
     def show_split(self, orientation):
+        closingFollowMode = self._followMode
         if self._followMode:
             self.show_follow_mode()
         if self._tabSecondary.isVisible() and \
@@ -176,7 +177,7 @@ class __MainContainer(QSplitter):
                 if type(widget) is editor.Editor and widget.textModified:
                     self._tabMain.tab_was_modified(True)
             self.actualTab = self._tabMain
-        elif not self._tabSecondary.isVisible():
+        elif not self._tabSecondary.isVisible() and not closingFollowMode:
             widget = self.get_actual_widget()
             name = unicode(self._tabMain.tabText(self._tabMain.currentIndex()))
             self._tabSecondary.add_tab(widget, name)


### PR DESCRIPTION
2392aeae - when all the tabs open in the left pane were closed, the split wasn't automatically undone.
26f51e73 - while on follow mode, closing the right tab caused the split to reopen with an empty left pane.
