### PR TITLE
Update element from self.titles in TabWidget when a file is renamed

### DIFF
--- a/ninja_ide/gui/main_panel/tab_widget.py
+++ b/ninja_ide/gui/main_panel/tab_widget.py
@@ -401,7 +401,9 @@ class TabWidget(QTabWidget):
 
     def change_open_tab_name(self, index, newName):
         """Change the name of the tab at index, for the newName."""
+        self.remove_title(index)
         self.setTabText(index, newName)
+        self.titles.append(newName)
 
 
 class TabNavigator(QWidget):


### PR DESCRIPTION
If I rename a file, the tab names are not properly tracked. 

This causes a bug, if you rename a file, and after that you set again the original name, the tab name is expanded because Ninja thinks that already exists a tab with the same name. If you repeat it several times, Ninja freezes.
