### PR TITLE
fixed QShortcut initialization in ninja_ide/gui/actions.py

### DIFF
--- a/ninja_ide/gui/actions.py
+++ b/ninja_ide/gui/actions.py
@@ -252,7 +252,7 @@ class __Actions(QObject):
         for i in xrange(10):
             if sys.platform == "darwin":
                 short = TabShortcuts(
-                    QKeySequence(Qt.CTRL + Qt.ALT + key), self, i)
+                    QKeySequence(Qt.CTRL + Qt.ALT + key), self.ide, i)
             else:
                 short = TabShortcuts(QKeySequence(Qt.ALT + key), self.ide, i)
             key += 1


### PR DESCRIPTION
The current master seems to fail on startup due to what appears to be a simple typo in `ninja_ide/gui/actions.py` that is fixed by this PR.
