### PR TITLE
Temporary hack/fix for Mac OS X not to use the filewatcher.

### DIFF
--- a/ninja_ide/core/file_manager.py
+++ b/ninja_ide/core/file_manager.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 import threading
 import shutil
 import logging
@@ -18,6 +19,12 @@ logger = logging.getLogger('ninja_ide.gui.explorer.file_manager')
 DEBUG = logger.debug
 
 try:
+    if sys.platform == "darwin":
+        # Temporary hack to avoid using the filewatcher in Mac OS X, because it
+        # is causing Ninja to crash with an error like this:
+        #     "[Errno 24] Too many open files"
+        raise ImportError()
+
     from watchdog.observers import Observer
     from watchdog.events import FileSystemEventHandler
 


### PR DESCRIPTION
Temporary hack/fix for Mac OS X not to use the filewatcher.
Temporary hack/fix for Mac OS X not to use the filewatcher.
Temporary hack/fix for Mac OS X not to use the filewatcher.
Temporary hack/fix for Mac OS X not to use the filewatcher.
