### PR TITLE
Fixed issue #521 Cannot open Python Help page more than once.

### DIFF
--- a/ninja_ide/gui/main_panel/browser_widget.py
+++ b/ninja_ide/gui/main_panel/browser_widget.py
@@ -57,7 +57,7 @@ class BrowserWidget(QWidget, itab_item.ITabItem):
 
         if process is not None:
             time.sleep(0.5)
-            self.webFrame.reload()
+            self.webFrame.load(QUrl(url))
 
         if url == resources.START_PAGE_URL:
             self.webFrame.page().setLinkDelegationPolicy(


### PR DESCRIPTION
``` python
self.webFrame.reload()
```

doesn't seem to work (for me at least)

It works well when I load it another time.
I can run multiple instances of pydoc help page without any problem.
