### PR TITLE
quick live bugfix

### DIFF
--- a/ninja_ide/gui/main_panel/main_container.py
+++ b/ninja_ide/gui/main_panel/main_container.py
@@ -350,7 +350,8 @@ class __MainContainer(QSplitter):
             else:
                 directory = os.path.expanduser("~")
                 editorWidget = self.get_actual_editor()
-                current_project = self._parent.explorer.get_actual_project()
+                pexplorer = self._parent.explorer
+                current_project = pexplorer and pexplorer.get_actual_project()
                 if current_project is not None:
                     directory = current_project
                 elif editorWidget is not None and editorWidget.ID:


### PR DESCRIPTION
fixes
<**lucio**> gah
<**lucio**> Traceback (most recent call last):
<**lucio**>   File "/home/lucio/src/ninja-ide/ninja_ide/gui/main_panel/main_container.py", line 353, in open_file
<**lucio**>     current_project = self._parent.explorer.get_actual_project()
<__lucio__> AttributeError: 'NoneType' object has no attribute 'explorer'
