### PR TITLE
add twisted matrix postfixes for python file extensions

### DIFF
--- a/ninja_ide/addins/syntax/python.json
+++ b/ninja_ide/addins/syntax/python.json
@@ -3,7 +3,7 @@
     "#"
   ],
   "extension": [
-    "py", "pyw"
+    "py", "pyw", "rpy", "tac"
   ],
   "definition": [
     "def",


### PR DESCRIPTION
.rpy and .tac files now will get python syntax highlighting 
