### PR TITLE
Add .js to supported extensions

### DIFF
--- a/ninja_ide/core/settings.py
+++ b/ninja_ide/core/settings.py
@@ -149,6 +149,7 @@ SUPPORTED_EXTENSIONS = [
     '.ui',
     '.css',
     '.json',
+    '.js',
     '.ini']
 
 


### PR DESCRIPTION
When using ninja-ide to work on python web projects you often need to edit .js files. 
So it does make sense to include .js as a supported extension by default as .html and .css is included, too.
