### PR TITLE
Improved single file watcher.

### DIFF
--- a/ninja_ide/core/filesystem_notifications/linux.py
+++ b/ninja_ide/core/filesystem_notifications/linux.py
@@ -74,7 +74,10 @@ class QNotifier(QThread):
 
     def run(self):
         while self.keep_running:
-            self.notifier.process_events()
+            try:
+                self.notifier.process_events()
+            except OSError:
+                pass  # OSError: [Errno 2] No such file or directory happens
             e_dict = {}
             while len(self.event_queue):
                 e_type, e_path = self.event_queue.pop(0)

--- a/ninja_ide/gui/misc/web_render.py
+++ b/ninja_ide/gui/misc/web_render.py
@@ -40,4 +40,4 @@ class WebRender(QWidget):
 
     def render_from_html(self, html, url=None):
         url = url and QUrl(url) or ""
-        self.webFrame.setHtml(html, url, base)
+        self.webFrame.setHtml(html, url)


### PR DESCRIPTION
First of all, auto pull request message sucks, bigtime, second, I finished implementing SingleFileWatcher, what is missing? a way to plug this to the regular open, the amount of open_file methods confused me (and also the fact that it is 2AM) just plug the add_ and remove_ file watch methods to whatever is the actual opening of a single file and watch the magic, as you can see it is running every second and checking, I thing we can safely make this go up to 5 secs and perhaps trigger a manual tick on save and tab changed.
