### PR TITLE
Dock windows

### DIFF
--- a/ninja_ide/core/settings.py
+++ b/ninja_ide/core/settings.py
@@ -50,9 +50,8 @@ MIN_OPACITY = 0.3
 
 TOOLBAR_AREA = 1
 #UI LAYOUT
-#001 : Central Rotate
-#010 : Panels Rotate
-#100 : Central Orientation
+#0 : Allow vertical orientation for lateral dock
+#1 : Not allow vertical orientation for lateral dock
 UI_LAYOUT = 0
 
 LANGUAGE = ""

--- a/ninja_ide/gui/central_widget.py
+++ b/ninja_ide/gui/central_widget.py
@@ -79,13 +79,18 @@ class __CentralWidget(QWidget):
     def insert_lateral_container(self, container):
         self.lateralDock = LateralDock(self.tr("Explorer"), container)
         self.lateralDock.setObjectName('explorer')
-        self.lateralDock.setAllowedAreas(Qt.LeftDockWidgetArea |
-            Qt.RightDockWidgetArea)
-        self.parent.addDockWidget(Qt.RightDockWidgetArea, self.lateralDock)
+        if settings.UI_LAYOUT:
+            self.lateralDock.setAllowedAreas(Qt.TopDockWidgetArea | 
+                Qt.BottomDockWidgetArea)
+            self.parent.addDockWidget(Qt.BottomDockWidgetArea, self.lateralDock,
+                Qt.Vertical)
+        else:
+            self.lateralDock.setAllowedAreas(Qt.LeftDockWidgetArea |
+                Qt.RightDockWidgetArea)
+            self.parent.addDockWidget(Qt.RightDockWidgetArea, self.lateralDock)
 
     def insert_bottom_container(self, container):
         self.misc = container
-        #self._splitterMain.insertWidget(1, container)
         self.bottomDock = BottomDock(self.tr("Console"), container)
         self.bottomDock.setObjectName('console')
         self.bottomDock.setAllowedAreas(Qt.TopDockWidgetArea |
@@ -119,35 +124,19 @@ class __CentralWidget(QWidget):
         else:
             self.lateralDock.show()
 
-    def lateral_dock_rotate(self):
-        area = self.parent.dockWidgetArea(self.lateralDock)
-        self.parent.removeDockWidget(self.lateralDock)
-        if area == Qt.RightDockWidgetArea:
-            self.parent.addDockWidget(Qt.LeftDockWidgetArea, self.lateralDock)
-        else:
-            self.parent.addDockWidget(Qt.RightDockWidgetArea, self.lateralDock)
-        self.lateralDock.show()
-
     def dock_orientation(self):
         if self.lateralDock.isAreaAllowed(Qt.RightDockWidgetArea):
             self.parent.removeDockWidget(self.lateralDock)
-            self.lateralDock.setAllowedAreas(Qt.TopDockWidgetArea | Qt.BottomDockWidgetArea)
-            self.parent.addDockWidget(Qt.BottomDockWidgetArea,
-                self.lateralDock, Qt.Vertical)
+            self.lateralDock.setAllowedAreas(Qt.TopDockWidgetArea |
+                Qt.BottomDockWidgetArea)
+            self.parent.addDockWidget(Qt.BottomDockWidgetArea, self.lateralDock,
+                Qt.Vertical)
         else:
             self.parent.removeDockWidget(self.lateralDock)
-            self.lateralDock.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+            self.lateralDock.setAllowedAreas(Qt.LeftDockWidgetArea |
+                Qt.RightDockWidgetArea)
             self.parent.addDockWidget(Qt.RightDockWidgetArea, self.lateralDock)
         self.lateralDock.show()
-
-    def bottom_dock_rotate(self):
-        area = self.parent.dockWidgetArea(self.bottomDock)
-        self.parent.removeDockWidget(self.bottomDock)
-        if area == Qt.TopDockWidgetArea:
-            self.parent.addDockWidget(Qt.BottomDockWidgetArea, self.bottomDock)
-        else:
-            self.parent.addDockWidget(Qt.TopDockWidgetArea, self.bottomDock)
-        self.bottomDock.show()
 
     def get_main_sizes(self):
         if self.misc.isVisible():

--- a/ninja_ide/gui/dialogs/preferences.py
+++ b/ninja_ide/gui/dialogs/preferences.py
@@ -458,28 +458,14 @@ class InterfaceTab(QWidget):
         vboxExplorer.addWidget(self._checkWebInspetor)
         vboxExplorer.addWidget(self._checkFileErrors)
         #GUI
-        self._btnCentralRotate = QPushButton(
-            QIcon(resources.IMAGES['splitCPosition']), '')
-        self._btnCentralRotate.setIconSize(QSize(64, 64))
-        self._btnCentralRotate.setCheckable(True)
-        self._btnPanelsRotate = QPushButton(
-            QIcon(resources.IMAGES['splitMPosition']), '')
-        self._btnPanelsRotate.setIconSize(QSize(64, 64))
-        self._btnPanelsRotate.setCheckable(True)
         self._btnCentralOrientation = QPushButton(
             QIcon(resources.IMAGES['splitCRotate']), '')
         self._btnCentralOrientation.setIconSize(QSize(64, 64))
         self._btnCentralOrientation.setCheckable(True)
         gridGuiConfig = QGridLayout(groupBoxGui)
-        gridGuiConfig.addWidget(self._btnCentralRotate, 0, 0)
-        gridGuiConfig.addWidget(self._btnPanelsRotate, 0, 1)
-        gridGuiConfig.addWidget(self._btnCentralOrientation, 0, 2)
+        gridGuiConfig.addWidget(self._btnCentralOrientation, 0, 0)
         gridGuiConfig.addWidget(QLabel(
-            self.tr("Rotate Central")), 1, 0, Qt.AlignCenter)
-        gridGuiConfig.addWidget(QLabel(
-            self.tr("Rotate Lateral")), 1, 1, Qt.AlignCenter)
-        gridGuiConfig.addWidget(QLabel(
-            self.tr("Central Orientation")), 1, 2, Qt.AlignCenter)
+            self.tr("Central Orientation")), 1, 0, Qt.AlignCenter)
         #GUI - Toolbar
         vbox_toolbar = QVBoxLayout(groupBoxToolbar)
         hbox_select_items = QHBoxLayout()
@@ -527,11 +513,8 @@ class InterfaceTab(QWidget):
         self._checkWebInspetor.setChecked(settings.SHOW_WEB_INSPECTOR)
         self._checkFileErrors.setChecked(settings.SHOW_ERRORS_LIST)
         #ui layout
-        self._btnCentralRotate.setChecked(bin(settings.UI_LAYOUT)[-1] == '1')
-        self._btnPanelsRotate.setChecked(bin(
-            settings.UI_LAYOUT >> 1)[-1] == '1')
-        self._btnCentralOrientation.setChecked(
-            bin(settings.UI_LAYOUT >> 2)[-1] == '1')
+        if settings.UI_LAYOUT:
+            self._btnCentralOrientation.setChecked(True)
 
         vbox.addWidget(groupBoxExplorer)
         vbox.addWidget(groupBoxGui)
@@ -539,10 +522,6 @@ class InterfaceTab(QWidget):
         vbox.addWidget(groupBoxLang)
 
         #Signals
-        self.connect(self._btnCentralRotate, SIGNAL('clicked()'),
-            central_widget.CentralWidget().bottom_dock_rotate)
-        self.connect(self._btnPanelsRotate, SIGNAL('clicked()'),
-            central_widget.CentralWidget().lateral_dock_rotate)
         self.connect(self._btnCentralOrientation, SIGNAL('clicked()'),
             central_widget.CentralWidget().dock_orientation)
         self.connect(self._btnItemAdd, SIGNAL("clicked()"),
@@ -714,9 +693,7 @@ class InterfaceTab(QWidget):
         else:
             explorer_container.ExplorerContainer().remove_tab_errors()
         #ui layout
-        uiLayout = 1 if self._btnCentralRotate.isChecked() else 0
-        uiLayout += 2 if self._btnPanelsRotate.isChecked() else 0
-        uiLayout += 4 if self._btnCentralOrientation.isChecked() else 0
+        uiLayout = 1 if self._btnCentralOrientation.isChecked() else 0
         qsettings.setValue('uiLayout', uiLayout)
         qsettings.setValue('toolbar', settings.TOOLBAR_ITEMS)
         qsettings.setValue('language', lang)

--- a/ninja_ide/gui/ide.py
+++ b/ninja_ide/gui/ide.py
@@ -179,7 +179,7 @@ class __IDE(QMainWindow):
         self.connect(self.mainContainer, SIGNAL("fileSaved(QString)"),
             self.show_status_message)
         #Load the size and the position of the main window
-        self.load_window_geometry()
+        #self.load_window_geometry()
 
     def _process_connection(self):
         connection = self.s_listener.nextPendingConnection()
@@ -393,10 +393,14 @@ class __IDE(QMainWindow):
     def load_window_geometry(self):
         """Load from QSettings the window size of de Ninja IDE"""
         qsettings = QSettings()
-        self.restoreGeometry(qsettings.value("window/geometry").toByteArray())
         self.restoreState(qsettings.value("window/state").toByteArray())
         if qsettings.value("window/maximized", True).toBool():
             self.setWindowState(Qt.WindowMaximized)
+        else:
+            self.restoreGeometry(qsettings.value("window/geometry").toByteArray())
+
+    def showEvent(self, event):
+        self.load_window_geometry()
 
     def closeEvent(self, event):
         if self.s_listener:


### PR DESCRIPTION
1. Removed 'splitterArea' (not needed after placing lateral panel in QDockWidget) - Fixed  Issue #827
2. Place console in dock window (removed '_splitterMain')
3. Save/restore state with using built-in method of QMainWindow (saveState/restoreState, saveGeometry/restoreGeometry)
