### PR TITLE
Fixed #930

### DIFF
--- a/ninja_ide/gui/main_panel/main_container.py
+++ b/ninja_ide/gui/main_panel/main_container.py
@@ -513,7 +513,7 @@ class __MainContainer(QSplitter):
         except file_manager.NinjaIOException as reason:
             if not notStart:
                 QMessageBox.information(self,
-                    self.tr("The file couldn't be open"), reason)
+                    self.tr("The file couldn't be open"), str(reason))
         except Exception as reason:
             logger.error('open_file: %s', reason)
         self.actualTab.notOpening = True


### PR DESCRIPTION
Note: Urgent patch due to the bug causes ninja-ide not to start. (#930)

The `reason` is converted to a string, which by default just returns the
message given.
