### PR TITLE
Add a new option to hide the Project Explorer Panel on startup

### DIFF
--- a/ninja_ide/core/settings.py
+++ b/ninja_ide/core/settings.py
@@ -269,6 +269,7 @@ def load_settings():
     global TOOLBAR_AREA
     global LANGUAGE
     global SHOW_START_PAGE
+    global SHOW_EXPLORER_PANEL
     global CONFIRM_EXIT
     global UI_LAYOUT
     global NOTIFY_UPDATES
@@ -317,6 +318,8 @@ def load_settings():
     LANGUAGE = qsettings.value('preferences/interface/language', '')
     SHOW_START_PAGE = qsettings.value(
         'preferences/general/showStartPage', 'true') == 'true'
+    SHOW_EXPLORER_PANEL = qsettings.value(
+        'preferences/general/showExplorerPanel', 'true') == 'true'
     CONFIRM_EXIT = qsettings.value('preferences/general/confirmExit',
         'true') == 'true'
     UI_LAYOUT = int(qsettings.value('preferences/interface/uiLayout', 0))

--- a/ninja_ide/gui/dialogs/preferences.py
+++ b/ninja_ide/gui/dialogs/preferences.py
@@ -171,10 +171,12 @@ class GeneralConfiguration(QWidget):
         self._checkNotifyUpdates = QCheckBox(
             self.tr("Notify me of new updates."))
         self._checkShowStartPage = QCheckBox(self.tr("Show Start Page"))
+        self._checkShowExplorerPanel = QCheckBox(self.tr("Show Explorer Panel"))
         vboxStart.addWidget(self._checkLastSession)
         vboxStart.addWidget(self._checkActivatePlugins)
         vboxStart.addWidget(self._checkNotifyUpdates)
         vboxStart.addWidget(self._checkShowStartPage)
+        vboxStart.addWidget(self._checkShowExplorerPanel)
         #Close
         vboxClose = QVBoxLayout(groupBoxClose)
         self._checkConfirmExit = QCheckBox(self.tr("Confirm Exit."))
@@ -212,6 +214,7 @@ class GeneralConfiguration(QWidget):
             qsettings.value('activatePlugins', 'true') == 'true')
         self._checkNotifyUpdates.setChecked(settings.NOTIFY_UPDATES)
         self._checkShowStartPage.setChecked(settings.SHOW_START_PAGE)
+        self._checkShowExplorerPanel.setChecked(settings.SHOW_EXPLORER_PANEL)
         self._checkConfirmExit.setChecked(settings.CONFIRM_EXIT)
         self._txtWorkspace.setText(settings.WORKSPACE)
         extensions = ', '.join(settings.SUPPORTED_EXTENSIONS)
@@ -251,6 +254,8 @@ class GeneralConfiguration(QWidget):
             self._checkNotifyUpdates.isChecked())
         qsettings.setValue('showStartPage',
             self._checkShowStartPage.isChecked())
+        qsettings.setValue('showExplorerPanel',
+            self._checkShowExplorerPanel.isChecked())
         settings.NOTIFY_UPDATES = self._checkNotifyUpdates.isChecked()
         qsettings.setValue('confirmExit', self._checkConfirmExit.isChecked())
         settings.CONFIRM_EXIT = self._checkConfirmExit.isChecked()

--- a/ninja_ide/gui/ide.py
+++ b/ninja_ide/gui/ide.py
@@ -297,6 +297,10 @@ class __IDE(QMainWindow):
         if settings.SHOW_START_PAGE:
             self.mainContainer.show_start_page()
 
+        if not settings.SHOW_EXPLORER_PANEL:
+            centralWidget._splitterAreaSizes = centralWidget._splitterArea.sizes()
+            centralWidget.lateralPanel.hide()
+
     def _show_preferences(self):
         pref = preferences.PreferencesWidget(self.mainContainer)
         pref.show()


### PR DESCRIPTION
I don't use the project explorer feature at all, and found that I had to press F2 every single time I started the program. This patch adds a startup option which prevents the displaying of Project Explorer.
