### PR TITLE
Add way to abort execution of command in console

### DIFF
--- a/ninja_ide/gui/misc/console_widget.py
+++ b/ninja_ide/gui/misc/console_widget.py
@@ -25,6 +25,8 @@ from PyQt4.QtGui import QTextCursor
 from PyQt4.QtGui import QTextFormat
 from PyQt4.QtGui import QTextEdit
 from PyQt4.QtGui import QColor
+from PyQt4 import QtCore
+from PyQt4.QtCore import QThread
 from PyQt4.QtCore import Qt
 from PyQt4.QtCore import QProcess
 from PyQt4.QtCore import QRegExp
@@ -46,6 +48,28 @@ BRACES = {"'": "'",
     '{': '}',
     '[': ']',
     '(': ')'}
+
+locked = False
+
+
+class WriteThread(QThread):
+    outputted = QtCore.pyqtSignal(str, bool)
+
+    def __init__(self, console, line):
+        global locked
+        locked = True
+
+        self.console = console
+        self.line = line
+
+        super(WriteThread, self).__init__()
+
+    def run(self):
+        incomplete = self.console.push(self.line)
+        self.outputted.emit(self.line, incomplete)
+
+        global locked
+        locked = False
 
 
 class ConsoleWidget(QPlainTextEdit):
@@ -69,7 +93,6 @@ class ConsoleWidget(QPlainTextEdit):
         self.completer = completer_widget.CompleterWidget(self)
         self.okPrefix = QRegExp('[.)}:,\]]')
 
-        #Create Context Menu
         self._create_context_menu()
 
         self._highlighter = highlighter.Highlighter(self.document(), 'python',
@@ -156,6 +179,17 @@ class ConsoleWidget(QPlainTextEdit):
             self.moveCursor(QTextCursor.Right, mode)
 
     def keyPressEvent(self, event):
+        global locked
+        if locked:
+            if event.key() == Qt.Key_C \
+            and event.modifiers() == Qt.ControlModifier:
+                self.write_thread.terminate()
+                locked = False
+                self._add_prompt(False)
+                event.accept()
+            else:
+                event.ignore()
+            return
         if self.completer.popup().isVisible():
             if event.key() in (Qt.Key_Enter, Qt.Key_Return, Qt.Key_Tab):
                 event.ignore()
@@ -423,9 +457,10 @@ class ConsoleWidget(QPlainTextEdit):
         #remove the prompt from the QString
         command = command[len(self.prompt):]
         self._add_history(command)
-        incomplete = self._write(command)
-        if self.patFrom.match(command) or \
-        self.patImport.match(command):
+        self._write(command)
+
+    def _write_helper(self, command, incomplete):
+        if self.patFrom.match(command) or self.patImport.match(command):
             self.imports += [command]
         if not incomplete:
             output = self._read()
@@ -452,7 +487,10 @@ class ConsoleWidget(QPlainTextEdit):
         self.popup_menu.exec_(event.globalPos())
 
     def _write(self, line):
-        return self._console.push(line)
+        console = self._console
+        self.write_thread = WriteThread(console, line)
+        self.write_thread.outputted.connect(self._write_helper)
+        self.write_thread.start()
 
     def _read(self):
         return self._console.output


### PR DESCRIPTION
Changes made:-
- moved command execution code that calls InteractiveConsole to separate class inheriting from QThread
- modified code in keyPressEvent to terminate the thread on pressing Ctrl+C in the console.

This is in response to issue #276.

**Update:** The new pull request is https://github.com/ninja-ide/ninja-ide/pull/1119. I made a new one as I'd accidentally created this from my master branch.
