### PR TITLE
Possible Fix For Issue 1083

### DIFF
--- a/ninja_ide/gui/editor/highlighter.py
+++ b/ninja_ide/gui/editor/highlighter.py
@@ -116,7 +116,10 @@ class Syntax(QTextBlock):
 
     def userData(self):
         user_data = super(Syntax, self).userData()
-        return SyntaxUserData(parentdata=user_data)
+        if user_data:
+            user_data = SyntaxUserData(parentdata=user_data)
+
+        return user_data
 
 
 class Highlighter(QSyntaxHighlighter):
@@ -140,7 +143,10 @@ class Highlighter(QSyntaxHighlighter):
 
     def currentBlock(self):
         block = super(Highlighter, self).currentBlock()
-        return Syntax(parentdata=block)
+        if block:
+            block = Syntax(parentdata=block)
+
+        return block
 
     def sanitize(self, word):
         """Sanitize the string to avoid problems with the regex."""

--- a/ninja_ide/gui/editor/syntax_highlighter.py
+++ b/ninja_ide/gui/editor/syntax_highlighter.py
@@ -76,7 +76,10 @@ class Syntax(QTextBlock):
 
     def userData(self):
         user_data = super(Syntax, self).userData()
-        return SyntaxUserData(parentdata=user_data)
+        if user_data:
+            user_data = SyntaxUserData(parentdata=user_data)
+
+        return user_data
 
 
 class TextCharFormat(QTextCharFormat):
@@ -340,7 +343,10 @@ class SyntaxHighlighter(QSyntaxHighlighter):
 
     def currentBlock(self):
         block = super(SyntaxHighlighter, self).currentBlock()
-        return Syntax(parentdata=block)
+        if block:
+            block = Syntax(parentdata=block)
+
+        return block
 
     def __apply_proper_style(self, char_format, color):
         if settings.UNDERLINE_NOT_BACKGROUND:


### PR DESCRIPTION
As I mentioned in my comment on issue 1083, it seems legitimate.  Both Highlighter and SyntaxHighlighter were expecting to be able to access attributes that are set in the SyntaxUserData constructor, even in cases where they were getting back a QTextBlockUserData.  For me, this caused Ninja IDE to stop highlighting syntax every time I started using it.

My fix is most likely not the best one, but it is a possible fix.  After creating the fix, I'm no longer getting any errors in my output, and syntax highlighting doesn't disappear as soon as I start typing.
