### PR TITLE
Gitignore *.pyo objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ninja_ide/addins/plugins/*
 NINJA_IDE.egg-info/*
 build/*
 dist/*
+
+*.pyo


### PR DESCRIPTION
Running Ninja-ide creates .pyo files which will clutter the source.
Ignore them.
