### PR TITLE
Check for _mini

### DIFF
--- a/ninja_ide/gui/editor/editor.py
+++ b/ninja_ide/gui/editor/editor.py
@@ -131,8 +131,6 @@ class Editor(QPlainTextEdit, itab_item.ITabItem):
         self.__encoding = None
         #Completer
         self.completer = completer_widget.CodeCompletionWidget(self)
-        #Indentation
-        self.set_project(project_obj)
         #Flag to dont bug the user when answer *the modification dialog*
         self.ask_if_externally_modified = False
         self.just_saved = False
@@ -193,6 +191,8 @@ class Editor(QPlainTextEdit, itab_item.ITabItem):
             self.connect(self, SIGNAL("updateRequest(const QRect&, int)"),
                 self._mini.update_visible_area)
 
+        #Indentation
+        self.set_project(project_obj)
         #Context Menu Options
         self.__actionFindOccurrences = QAction(
             self.tr("Find Usages"), self)
@@ -242,7 +242,7 @@ class Editor(QPlainTextEdit, itab_item.ITabItem):
     def set_tab_usage(self):
         tab_size = self.pos_margin / settings.MARGIN_LINE * self.indent
         self.setTabStopWidth(tab_size)
-        if hasattr(self, '_mini') and self._mini:
+        if self._mini:
             self._mini.setTabStopWidth(tab_size)
 
     def set_id(self, id_):


### PR DESCRIPTION
I recently started working on a couple of projects written in Go and didn't feel like getting a new editor to work with them - so I just created the project in ninja-ide.  Because Go recommends the use of tabs in its syntax guide, I set the properties of the new project to use tabs.

After I set the project to use tabs, I noticed that it was refusing to open any new files, so I turned on debugging and traced it down to gui.editor.Editor.set_tab_usage.  The statement "if self._mini" was assuming that the attribute "_mini" exists, but it doesn't when opening new files.  So I just set it to check for _mini with hasattr before checking to see if it evaluates to True.
