### PR TITLE
Fix unindent behavior

### DIFF
--- a/ninja_ide/gui/editor/editor.py
+++ b/ninja_ide/gui/editor/editor.py
@@ -222,7 +222,7 @@ class Editor(QPlainTextEdit, itab_item.ITabItem):
         previous_spaces = helpers.get_indentation(previous_text)
         current_spaces = helpers.get_indentation(current_text)
 
-        if len(previous_spaces) != len(current_spaces):
+        if len(previous_spaces) < len(current_spaces):
             last_word = helpers.get_first_keyword(current_text)
 
             if last_word in ALLOWS_LESS_INDENTATION_KEYWORDS:


### PR DESCRIPTION
In case you already unindented (previous spaces > current spaces),
it tried to unindent with a negative diff.

For example:

```
if a:
    if b:
        pass
else:
```

The else was unindented and replaced by itself[-4], resulting in

```
if a:
    if b:
        pass
lse:
```

Unindent is only relevant in one way, when len(previous_spaces) < len(current_spaces)
