### PR TITLE
Fixed window being in background in osx

### DIFF
--- a/ninja_ide/gui/__init__.py
+++ b/ninja_ide/gui/__init__.py
@@ -155,9 +155,9 @@ def start_ide(app, filenames, projects_path, extra_plugins, linenos):
     ninjaide.show()
     #OSX workaround for ninja window not in front
     try:
-	ninjaide.raise_()
+        ninjaide.raise_()
     except:
-	pass  # I really dont mind if this fails in any form
+        pass  # I really dont mind if this fails in any form
     #Loading Session Files
     splash.showMessage("Loading Files and Projects",
         Qt.AlignRight | Qt.AlignTop, Qt.black)


### PR DESCRIPTION
When starting up on osx, ninja' s main window will stay on background, this snippet fixes the issue
