### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 # 2013-11-13T16:39:56 by gatox .travis.yml Continuous Integration by Ninja-IDE
 language: python
 python:
-
-
     - 2.7
-
     - 3.3
-
-before_install: sudo apt-get update -qq ; sudo apt-get install -qq sloccount python-qt4 python3-pyqt4 sip-dev python3-sip python-sip python-sip-dev; pip install pep8 pip-tools coviolations_app coverage --use-mirrors;
+before_install: 
+    - sudo apt-get update -qq ; sudo apt-get install -qq sloccount python-qt4 python3-pyqt4 sip-dev python3-sip python-sip python-sip-dev; pip install pep8 pip-tools coviolations_app coverage --use-mirrors;
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start" 
 install: true
 before_script: rm --recursive --force --verbose *.pyc
 script: ./run-tests ninja_tests
 after_script: coverage report
 after_success: covio
 after_failure: covio
-# after_failure: true  # runs when failed
 notifications:
     irc:
         channels: "irc.freenode.org#ninja-ide"


### PR DESCRIPTION
Add xvfb (X Virtual Framebuffer) virtual screen support for future testing.

According to official Docs at:
http://about.travis-ci.org/docs/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-GUI-(e.g.-a-Web-browser)
