### PR TITLE
Don't try to open directories as files from sidebar

### DIFF
--- a/ninja_ide/gui/explorer/tabs/tree_projects_widget.py
+++ b/ninja_ide/gui/explorer/tabs/tree_projects_widget.py
@@ -587,6 +587,8 @@ class TreeProjectsWidget(QTreeView):
             self._added_to_console = False
 
     def _open_file(self, model_index):
+        if self.model().isDir(model_index):
+            return
         path = self.model().filePath(model_index)
         main_container = IDE.get_service('main_container')
         logger.debug("tried to get main container")


### PR DESCRIPTION
Console was filling up with tracebacks due to trying to open directories as files in the editor. Don't know if this is the best way to do this.
