### PR TITLE
[Dialogs] Fix for #1618

### DIFF
--- a/ninja_ide/gui/dialogs/language_manager.py
+++ b/ninja_ide/gui/dialogs/language_manager.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NINJA-IDE; If not, see <http://www.gnu.org/licenses/>.
 
+
 import os
 #lint:disable
 try:
@@ -43,11 +44,12 @@ from ninja_ide.tools import json_manager
 
 
 class LanguagesManagerWidget(QDialog):
+    """Languages Manager dialog class"""
 
     def __init__(self, parent):
         QDialog.__init__(self, parent, Qt.Dialog)
         self.setWindowTitle(self.tr("Language Manager"))
-        self.resize(700, 500)
+        self.setMinimumSize(ui_tools.get_modal_size())
 
         vbox = QVBoxLayout(self)
         self._tabs = QTabWidget()
@@ -76,12 +78,14 @@ class LanguagesManagerWidget(QDialog):
         self._reload_languages()
 
     def _reload_languages(self):
+        """Show overlay and reload all languages"""
         self.overlay.show()
         self._loading = True
         self._thread.execute = self.execute_thread
         self._thread.start()
 
     def load_languages_data(self):
+        """Load languages data on the GUI"""
         if self._loading:
             self._tabs.clear()
             self._languageWidget = LanguageWidget(self, self._languages)
@@ -92,16 +96,19 @@ class LanguagesManagerWidget(QDialog):
         self._thread.wait()
 
     def download_language(self, language):
+        """Take a language argument, show the overlay and download it"""
         self.overlay.show()
         self.downloadItems = language
         self._thread.execute = self._download_language_thread
         self._thread.start()
 
     def resizeEvent(self, event):
+        """Handle Resize event"""
         self.overlay.resize(event.size())
         event.accept()
 
     def execute_thread(self):
+        """Execute a downloader thread"""
         try:
             descriptor_languages = urlopen(resources.LANGUAGES_URL)
             languages = json_manager.parse(descriptor_languages)
@@ -114,6 +121,7 @@ class LanguagesManagerWidget(QDialog):
             self._languages = []
 
     def get_local_languages(self):
+        """Get all languages already available locally"""
         if not file_manager.folder_exists(resources.LANGS_DOWNLOAD):
             file_manager.create_tree_folders(resources.LANGS_DOWNLOAD)
         languages = os.listdir(resources.LANGS_DOWNLOAD) + \
@@ -122,10 +130,12 @@ class LanguagesManagerWidget(QDialog):
         return languages
 
     def _download_language_thread(self):
+        """Iterate over all items downloading them"""
         for d in self.downloadItems:
             self.download(d[1], resources.LANGS_DOWNLOAD)
 
     def download(self, url, folder):
+        """Download url argument on folder argument"""
         fileName = os.path.join(folder, os.path.basename(url))
         try:
             content = urlopen(url)
@@ -136,6 +146,7 @@ class LanguagesManagerWidget(QDialog):
 
 
 class LanguageWidget(QWidget):
+    """Language internal widget class"""
 
     def __init__(self, parent, languages):
         QWidget.__init__(self, parent)
@@ -157,6 +168,7 @@ class LanguageWidget(QWidget):
             self._download_language)
 
     def _download_language(self):
+        """Download a language calling parent class method"""
         languages = ui_tools.remove_get_selected_items(self._table,
             self._languages)
         self._parent.download_language(languages)

--- a/ninja_ide/gui/dialogs/plugins_manager.py
+++ b/ninja_ide/gui/dialogs/plugins_manager.py
@@ -92,7 +92,7 @@ class PluginsManagerWidget(QDialog):
     def __init__(self, parent):
         QDialog.__init__(self, parent, Qt.Dialog)
         self.setWindowTitle(translations.TR_PLUGIN_MANAGER)
-        self.resize(700, 600)
+        self.setMinimumSize(ui_tools.get_modal_size())
 
         vbox = QVBoxLayout(self)
         self._tabs = QTabWidget()
@@ -641,7 +641,7 @@ class DependenciesHelpDialog(QDialog):
     def __init__(self, requirements_dict):
         super(DependenciesHelpDialog, self).__init__()
         self.setWindowTitle(translations.TR_REQUIREMENTS)
-        self.resize(525, 400)
+        self.setMinimumSize(ui_tools.get_modal_size())
         vbox = QVBoxLayout(self)
         label = QLabel(translations.TR_SOME_PLUGINS_NEED_DEPENDENCIES)
         vbox.addWidget(label)

--- a/ninja_ide/gui/dialogs/preferences/preferences.py
+++ b/ninja_ide/gui/dialogs/preferences/preferences.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NINJA-IDE; If not, see <http://www.gnu.org/licenses/>.
 
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -30,11 +31,11 @@ from PyQt4.QtGui import QHeaderView
 from PyQt4.QtGui import QPushButton
 from PyQt4.QtGui import QSpacerItem
 from PyQt4.QtGui import QSizePolicy
-from PyQt4.QtCore import QSize
 from PyQt4.QtCore import Qt
 from PyQt4.QtCore import SIGNAL
 
 from ninja_ide import translations
+from ninja_ide.tools import ui_tools
 
 
 SECTIONS = {
@@ -47,6 +48,7 @@ SECTIONS = {
 
 
 class Preferences(QDialog):
+    """Preferences dialog widget class"""
 
     configuration = {}
     weight = 0
@@ -54,8 +56,7 @@ class Preferences(QDialog):
     def __init__(self, parent=None):
         super(Preferences, self).__init__(parent, Qt.Dialog)
         self.setWindowTitle(translations.TR_PREFERENCES_TITLE)
-        self.setMinimumSize(QSize(900, 600))
-        self.setMaximumSize(QSize(0, 0))
+        self.setMinimumSize(ui_tools.get_modal_size())
         vbox = QVBoxLayout(self)
         hbox = QHBoxLayout()
         vbox.setContentsMargins(0, 0, 5, 5)
@@ -93,10 +94,12 @@ class Preferences(QDialog):
         self.tree.setCurrentItem(self.tree.topLevelItem(0))
 
     def _save_preferences(self):
+        """Method to save the preferences and close the dialog"""
         self.emit(SIGNAL("savePreferences()"))
         self.close()
 
     def load_ui(self):
+        """Load the preferences widget items"""
         sections = sorted(list(Preferences.configuration.keys()),
             key=lambda item: Preferences.configuration[item]['weight'])
         for section in sections:
@@ -131,6 +134,7 @@ class Preferences(QDialog):
         self.tree.expandAll()
 
     def _change_current(self):
+        """Change the current item on the preferences"""
         item = self.tree.currentItem()
         index = item.data(0, Qt.UserRole)
         self.stacked.setCurrentIndex(index)
@@ -138,6 +142,7 @@ class Preferences(QDialog):
     @classmethod
     def register_configuration(cls, section, widget, text, weight=None,
             subsection=None):
+        """Method to Register a new configuration on preferences"""
         if weight is None:
             Preferences.weight += 1
             weight = Preferences.weight

--- a/ninja_ide/gui/dialogs/project_properties_widget.py
+++ b/ninja_ide/gui/dialogs/project_properties_widget.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NINJA-IDE; If not, see <http://www.gnu.org/licenses/>.
 
+
 from __future__ import absolute_import
 
 import os
@@ -74,12 +75,13 @@ LICENCES = ('Academic Free License', 'Apache License 2.0',
 
 
 class ProjectProperties(QDialog):
+    """Project properties dialog class"""
 
     def __init__(self, project, parent=None):
         QDialog.__init__(self, parent, Qt.Dialog)
         self.project = project
         self.setWindowTitle(translations.TR_PROJECT_PROPERTIES)
-        self.resize(600, 500)
+        self.setMinimumSize(ui_tools.get_modal_size())
         vbox = QVBoxLayout(self)
         self.tab_widget = QTabWidget()
         self.projectData = ProjectData(self)
@@ -104,6 +106,7 @@ class ProjectProperties(QDialog):
         self.connect(self.btnSave, SIGNAL("clicked()"), self.save_properties)
 
     def save_properties(self):
+        """Save all properties and close the window"""
         if not len(self.projectData.name.text().strip()):
             QMessageBox.critical(self, translations.TR_PROJECT_SAVE_INVALID,
                 translations.TR_PROJECT_INVALID_MESSAGE)
@@ -139,6 +142,7 @@ class ProjectProperties(QDialog):
 
 
 class ProjectData(QWidget):
+    """Project Data internal widget for Project properties window"""
 
     def __init__(self, parent):
         super(ProjectData, self).__init__()
@@ -199,6 +203,7 @@ class ProjectData(QWidget):
 
 
 class ProjectExecution(QWidget):
+    """Project Execution internal widget for Project properties window"""
 
     def __init__(self, parent):
         super(ProjectExecution, self).__init__()
@@ -306,11 +311,13 @@ class ProjectExecution(QWidget):
             self.select_post_exec_script)
 
     def _load_python_path(self):
+        """Ask the user for a Python Path and set the provided value"""
         path = QFileDialog.getOpenFileName(
             translations.TR_PROJECT_SELECT_PYTHON_PATH)
         self.txtPythonInterpreter.setText(path)
 
     def _load_python_venv(self):
+        """Ask the user for a Python Virtualenv and set the value if it exist"""
         venv = QFileDialog.getExistingDirectory(
             translations.TR_PROJECT_SELECT_VIRTUALENV)
         if sys.platform == 'win32':
@@ -327,6 +334,7 @@ class ProjectExecution(QWidget):
             self.txtVenvPath.setText(venv)
 
     def select_file(self):
+        """Ask the user for a Python file and set its value if any"""
         fileName = QFileDialog.getOpenFileName(
             self, translations.TR_PROJECT_SELECT_MAIN_FILE,
                         self._parent.project.path, 'PY(*.py);;*(*.*)')
@@ -336,6 +344,7 @@ class ProjectExecution(QWidget):
             self.path.setText(fileName)
 
     def select_pre_exec_script(self):
+        """Ask the user for a Pre-Exec script file and set its value if any"""
         fileName = QFileDialog.getOpenFileName(
             self, translations.TR_PROJECT_SELECT_PRE_SCRIPT,
                         self._parent.project.path, '(*.*)')
@@ -345,6 +354,7 @@ class ProjectExecution(QWidget):
             self.txtPreExec.setText(fileName)
 
     def select_post_exec_script(self):
+        """Ask the user for a Post-Exec script file and set its value if any"""
         fileName = QFileDialog.getOpenFileName(
             self, translations.TR_PROJECT_SELECT_POST_SCRIPT,
                         self._parent.project.path, '(*.*)')
@@ -355,6 +365,7 @@ class ProjectExecution(QWidget):
 
 
 class ProjectMetadata(QWidget):
+    """Project Metadata internal widget for Project properties window"""
 
     def __init__(self, parent):
         super(ProjectMetadata, self).__init__()

--- a/ninja_ide/gui/dialogs/python_detect_dialog.py
+++ b/ninja_ide/gui/dialogs/python_detect_dialog.py
@@ -34,6 +34,7 @@ from ninja_ide.core import settings
 
 
 class PythonDetectDialog(QDialog):
+    """Python Detection dialog class"""
 
     def __init__(self, suggested, parent=None):
         super(PythonDetectDialog, self).__init__(parent, Qt.Dialog)
@@ -67,6 +68,7 @@ class PythonDetectDialog(QDialog):
         self.listPaths.setCurrentRow(0)
 
     def _set_python_path(self):
+        """Set a Python Path and close the window"""
         python_path = self.listPaths.currentItem().text()
 
         qsettings = QSettings(resources.SETTINGS_PATH, QSettings.IniFormat)

--- a/ninja_ide/gui/dialogs/session_manager.py
+++ b/ninja_ide/gui/dialogs/session_manager.py
@@ -33,6 +33,7 @@ from PyQt4.QtCore import SIGNAL
 from ninja_ide import translations
 from ninja_ide.core import settings
 from ninja_ide.core.file_handling import file_manager
+from ninja_ide.tools import ui_tools
 
 
 class SessionsManager(QDialog):
@@ -43,7 +44,7 @@ class SessionsManager(QDialog):
         super(SessionsManager, self).__init__(parent, Qt.Dialog)
         self._ide = parent
         self.setWindowTitle(translations.TR_SESSIONS_TITLE)
-        self.setMinimumWidth(400)
+        self.setMinimumSize(ui_tools.get_modal_size())
         vbox = QVBoxLayout(self)
         vbox.addWidget(QLabel(translations.TR_SESSIONS_DIALOG_BODY))
         self.sessionList = QListWidget()

--- a/ninja_ide/gui/dialogs/themes_manager.py
+++ b/ninja_ide/gui/dialogs/themes_manager.py
@@ -43,11 +43,12 @@ from ninja_ide.tools import json_manager
 
 
 class ThemesManagerWidget(QDialog):
+    """Themes manager dialog class"""
 
     def __init__(self, parent):
         QDialog.__init__(self, parent, Qt.Dialog)
         self.setWindowTitle(self.tr("Themes Manager"))
-        self.resize(700, 500)
+        self.setMinimumSize(ui_tools.get_modal_size())
 
         vbox = QVBoxLayout(self)
         self._tabs = QTabWidget()
@@ -75,12 +76,14 @@ class ThemesManagerWidget(QDialog):
         self._reload_themes()
 
     def _reload_themes(self):
+        """Display the overlay and reload all themes"""
         self.overlay.show()
         self._loading = True
         self._thread.execute = self.execute_thread
         self._thread.start()
 
     def load_skins_data(self):
+        """Load all schemes data"""
         if self._loading:
             self._tabs.clear()
             self._schemeWidget = SchemeWidget(self, self._schemes)
@@ -90,16 +93,19 @@ class ThemesManagerWidget(QDialog):
         self._thread.wait()
 
     def download_scheme(self, scheme):
+        """Download an argument scheme"""
         self.overlay.show()
         self.downloadItems = scheme
         self._thread.execute = self._download_scheme_thread
         self._thread.start()
 
     def resizeEvent(self, event):
+        """Handle Resize event"""
         self.overlay.resize(event.size())
         event.accept()
 
     def execute_thread(self):
+        """Execute a download thread"""
         try:
             descriptor_schemes = urlopen(resources.SCHEMES_URL)
             schemes = json_manager.parse(descriptor_schemes)
@@ -112,6 +118,7 @@ class ThemesManagerWidget(QDialog):
             self._schemes = []
 
     def get_local_schemes(self):
+        """Return all already available local schemes"""
         if not file_manager.folder_exists(resources.EDITOR_SKINS):
             file_manager.create_tree_folders(resources.EDITOR_SKINS)
         schemes = os.listdir(resources.EDITOR_SKINS)
@@ -119,10 +126,12 @@ class ThemesManagerWidget(QDialog):
         return schemes
 
     def _download_scheme_thread(self):
+        """Iterate over all items downloading them"""
         for d in self.downloadItems:
             self.download(d[1], resources.EDITOR_SKINS)
 
     def download(self, url, folder):
+        """Download argument url on arguement folder"""
         fileName = os.path.join(folder, os.path.basename(url))
         try:
             content = urlopen(url)
@@ -133,6 +142,7 @@ class ThemesManagerWidget(QDialog):
 
 
 class SchemeWidget(QWidget):
+    """Scheme internal widget class for Scheme Manager parent window"""
 
     def __init__(self, parent, schemes):
         QWidget.__init__(self, parent)
@@ -153,5 +163,6 @@ class SchemeWidget(QWidget):
         self.connect(btnUninstall, SIGNAL("clicked()"), self._download_scheme)
 
     def _download_scheme(self):
+        """Download an scheme calling parent class method"""
         schemes = ui_tools.remove_get_selected_items(self._table, self._schemes)
         self._parent.download_scheme(schemes)

--- a/ninja_ide/gui/dialogs/traceback_widget.py
+++ b/ninja_ide/gui/dialogs/traceback_widget.py
@@ -29,6 +29,7 @@ from PyQt4.QtGui import QPushButton
 
 from PyQt4.QtCore import SIGNAL
 
+from ninja_ide.tools import ui_tools
 from ninja_ide import translations
 
 
@@ -39,7 +40,7 @@ class PluginErrorDialog(QDialog):
     def __init__(self):
         QDialog.__init__(self)
         self.setWindowTitle(translations.TR_PLUGIN_ERROR_REPORT)
-        self.resize(600, 400)
+        self.setMinimumSize(ui_tools.get_modal_size())
         vbox = QVBoxLayout(self)
         label = QLabel(translations.TR_SOME_PLUGINS_REMOVED)
         vbox.addWidget(label)

--- a/ninja_ide/gui/dialogs/wizard_new_project.py
+++ b/ninja_ide/gui/dialogs/wizard_new_project.py
@@ -43,6 +43,7 @@ from ninja_ide.core import settings
 from ninja_ide.core import plugin_interfaces
 from ninja_ide.core.file_handling import file_manager
 from ninja_ide.tools import json_manager
+from ninja_ide.tools import ui_tools
 from ninja_ide.tools.logger import NinjaLogger
 
 
@@ -66,6 +67,7 @@ class WizardNewProject(QWizard):
         self.__explorer = parent
         self.setWindowTitle(self.tr("NINJA - New Project Wizard"))
         self.setPixmap(QWizard.LogoPixmap, QPixmap(":img/icon"))
+        self.setMinimumSize(ui_tools.get_modal_size())
 
         self.option = 'Python'
         #Add a project type handler for Python
@@ -86,6 +88,7 @@ class WizardNewProject(QWizard):
             QWizard.FinishButton])
 
     def add_project_pages(self, option='Python'):
+        """Add a new page to the project"""
         logger.debug("Add project pages")
         self.option = option
         pages = settings.get_project_type_handler(option).get_pages()
@@ -99,6 +102,7 @@ class WizardNewProject(QWizard):
             self.removePage(i)
 
     def done(self, result):
+        """Display results when its done"""
         logger.debug("Done")
         if result == 1:
             page = self.currentPage()
@@ -244,6 +248,7 @@ class ImportFromSourcesProjectHandler(plugin_interfaces.IProjectTypeHandler):
 
 
 class PageProjectType(QWizardPage):
+    """Project Page Type class"""
 
     def __init__(self, wizard):
         QWizardPage.__init__(self)
@@ -266,10 +271,12 @@ class PageProjectType(QWizardPage):
             self.load_pages)
 
     def validatePage(self):
+        """Validate a Project page"""
         self._wizard.option = self.listWidget.currentItem().text()
         return True
 
     def load_pages(self):
+        """Load pages from current items"""
         self.wizard().add_project_pages(self.listWidget.currentItem().text())
 
 
@@ -279,6 +286,7 @@ class PageProjectType(QWizardPage):
 
 
 class PageProjectProperties(QWizardPage):
+    """Page of Project properties"""
 
     def __init__(self):
         QWizardPage.__init__(self)
@@ -350,15 +358,18 @@ class PageProjectProperties(QWizardPage):
             lambda: self.emit(SIGNAL("completeChanged()")))
 
     def isComplete(self):
+        """Return True if data is complete"""
         name = self.txtName.text().strip()
         place = self.txtPlace.text().strip()
         return (len(name) > 0) and (len(place) > 0)
 
     def load_folder(self):
+        """Ask the user a new project folder and set its value"""
         self.txtPlace.setText(QFileDialog.getExistingDirectory(
             self, self.tr("New Project Folder")))
         self.emit(SIGNAL("completeChanged()"))
 
     def load_folder_venv(self):
+        """Ask the user for a Python Virtualenv folder and set its value"""
         self.vtxtPlace.setText(QFileDialog.getExistingDirectory(
             self, self.tr("Select Virtualenv Folder")))

--- a/ninja_ide/tools/ui_tools.py
+++ b/ninja_ide/tools/ui_tools.py
@@ -48,6 +48,7 @@ from PyQt4.QtGui import QPushButton
 from PyQt4.QtGui import QCheckBox
 from PyQt4.QtGui import QTableWidget
 from PyQt4.QtGui import QKeySequence
+from PyQt4.QtGui import QDesktopWidget
 from PyQt4.QtCore import Qt
 from PyQt4.QtCore import QDir
 from PyQt4.QtCore import QUrl
@@ -56,6 +57,7 @@ from PyQt4.QtCore import SIGNAL
 from PyQt4.QtCore import QThread
 from PyQt4.QtCore import QEvent
 from PyQt4.QtCore import QTimeLine
+from PyQt4.QtCore import QSize
 
 from ninja_ide import resources
 from ninja_ide.core import settings
@@ -522,3 +524,9 @@ class TabShortcuts(QShortcut):
     def __init__(self, key, parent, index):
         super(TabShortcuts, self).__init__(key, parent)
         self.index = index
+
+
+def get_modal_size():
+    """Return a basic minimum size for Modal and Secondary Dialog Windows"""
+    return QSize(QDesktopWidget().screenGeometry().width() // 2.25,
+                 QDesktopWidget().screenGeometry().height() // 2.25)


### PR DESCRIPTION
- Fix for #1618  
- Remove hardcoded window sizes.
- Add new method to return dynamic homogeneous size for secondary dialog windows and modals.
- Allow resize of secondary dialog windows.
- PEP8 / Lint compliant.
- Add missing DocStrings.
- Short Fix but allows future improvement of get_modal_size helper function and avoids hardcoded integers.

Brancho: fix/remove_hardcoded_window_size  :tangerine: 
