### PR TITLE
[Find] Improve Find by grouping its widgets inside a QGroupbox

### DIFF
--- a/ninja_ide/gui/status_bar.py
+++ b/ninja_ide/gui/status_bar.py
@@ -35,6 +35,7 @@ from PyQt4.QtGui import QCheckBox
 from PyQt4.QtGui import QStyle
 from PyQt4.QtGui import QIcon
 from PyQt4.QtGui import QShortcut
+from PyQt4.QtGui import QGroupBox
 from PyQt4.QtCore import SIGNAL
 from PyQt4.QtCore import Qt
 
@@ -236,7 +237,7 @@ class _StatusBar(QStatusBar):
             widget.setFocus()
 
 
-class SearchWidget(QWidget):
+class SearchWidget(QGroupBox):
 
     """Search widget component, search for text inside the editor."""
 
@@ -250,18 +251,23 @@ class SearchWidget(QWidget):
         self._line.setMinimumWidth(250)
         self._btnClose = QPushButton(
             self.style().standardIcon(QStyle.SP_DialogCloseButton), '')
+        self._btnClose.setToolTip(translations.TR_CLOSE)
         self._btnFind = QPushButton(QIcon(":img/find"), '')
+        self._btnFind.setToolTip(translations.TR_FIND)
         self.btnPrevious = QPushButton(
-            self.style().standardIcon(QStyle.SP_ArrowLeft), '')
+            self.style().standardIcon(QStyle.SP_ArrowLeft),
+            translations.TR_PREVIOUS)
         self.btnPrevious.setToolTip(self.trUtf8("Press %s") %
                 resources.get_shortcut("Find-previous").toString(
                     QKeySequence.NativeText))
         self.btnNext = QPushButton(
-            self.style().standardIcon(QStyle.SP_ArrowRight), '')
+            self.style().standardIcon(QStyle.SP_ArrowRight),
+            translations.TR_NEXT)
         self.btnNext.setToolTip(self.trUtf8("Press %s") %
                 resources.get_shortcut("Find-next").toString(
                     QKeySequence.NativeText))
         hSearch.addWidget(self._btnClose)
+        hSearch.addWidget(QLabel(translations.TR_FIND))
         hSearch.addWidget(self._line)
         hSearch.addWidget(self._btnFind)
         hSearch.addWidget(self.btnPrevious)
@@ -403,23 +409,25 @@ class SearchWidget(QWidget):
         return current_index
 
 
-class ReplaceWidget(QWidget):
+class ReplaceWidget(QGroupBox):
 
     """Replace widget to find and replace occurrences of words in editor."""
 
     def __init__(self, parent=None):
-        QWidget.__init__(self, parent)
+        QGroupBox.__init__(self, parent)
         hReplace = QHBoxLayout(self)
         hReplace.setContentsMargins(0, 0, 0, 0)
         self._lineReplace = QLineEdit()
         self._lineReplace.setMinimumWidth(250)
         self._btnCloseReplace = QPushButton(
             self.style().standardIcon(QStyle.SP_DialogCloseButton), '')
+        self._btnCloseReplace.setToolTip(translations.TR_CLOSE)
         self._btnReplace = QPushButton(self.trUtf8("Replace"))
         self._btnReplaceAll = QPushButton(self.trUtf8("Replace All"))
         self._btnReplaceSelection = QPushButton(
             self.trUtf8("Replace Selection"))
         hReplace.addWidget(self._btnCloseReplace)
+        hReplace.addWidget(QLabel(translations.TR_REPLACE))
         hReplace.addWidget(self._lineReplace)
         hReplace.addWidget(self._btnReplace)
         hReplace.addWidget(self._btnReplaceAll)

--- a/ninja_ide/translations.py
+++ b/ninja_ide/translations.py
@@ -205,8 +205,8 @@ TR_IDE_TOOLBAR_TOOLTIP = tr("NINJA-IDE", "Press and Drag to Move")
 
 
 # Status Bar
-TR_SEARCH_CASE_SENSITIVE = tr("NINJA-IDE", "Respect case sensitive")
-TR_SEARCH_WHOLE_WORDS = tr("NINJA-IDE", "Find whole words")
+TR_SEARCH_CASE_SENSITIVE = tr("NINJA-IDE", "Case sensitive")
+TR_SEARCH_WHOLE_WORDS = tr("NINJA-IDE", "Whole words")
 
 
 # Checkers
@@ -289,8 +289,8 @@ TR_EXECUTE_PROJECT = tr("NINJA-IDE", "Execute current project")
 TR_DEBUG = tr("NINJA-IDE", "Debug")
 TR_SWITCH_KEYBOARD_FOCUS = tr("NINJA-IDE", "Switch keyboard focus")
 TR_STOP_EXECUTION = tr("NINJA-IDE", "Stop Execution")
-TR_FIND_NEXT = tr("NINJA-IDE", "Find Next")
-TR_FIND_PREVIOUS = tr("NINJA-IDE", "Find Previous")
+TR_FIND_NEXT = tr("NINJA-IDE", "Find next")
+TR_FIND_PREVIOUS = tr("NINJA-IDE", "Find previous")
 TR_SHOW_PYTHON_HELP = tr("NINJA-IDE", "Show Python Help")
 TR_SPLIT_TABS_VERTICAL = tr("NINJA-IDE", "Split Tabs Vertically")
 TR_SPLIT_TABS_HORIZONTAL = tr("NINJA-IDE", "Split Tabs Horizontally")
@@ -531,3 +531,5 @@ TR_DO_YOU_WANT_TO_REMOVE = tr("NINJA-IDE", "Do you want to remove it?")
 TR_LOAD_DEFAULTS = tr("NINJA-IDE", "Load defaults")
 TR_SHORTCUTS_ARE_GOING_TO_BE_REFRESH = tr("NINJA-IDE",
     "The Shortcut's Text in the Menus are going to be refreshed on restart.")
+TR_PREVIOUS = tr("NINJA-IDE", "Previous")
+TR_NEXT = tr("NINJA-IDE", "Next")


### PR DESCRIPTION
- Fix Find by grouping its widgets inside a QGroupbox.
- Fix Replace by grouping its widgets inside a QGroupbox.
- Update translations.
- PEP8 / Lint compliant.

![temp](https://f.cloud.github.com/assets/1189414/2372202/e0a2d1be-a836-11e3-8afd-fa61f551f54e.jpg)

The idea behind its to make more clear visually, ala 
_" What im closing with 2 Close buttons togheter?; Whats the Forward/Backward buttons for? "_

Brancho: fix/find :rabbit2: 
