### PR TITLE
[editor] Fix editor by removing pointless variable reassignment

### DIFF
--- a/ninja_ide/gui/editor/editor.py
+++ b/ninja_ide/gui/editor/editor.py
@@ -97,7 +97,6 @@ class Editor(QPlainTextEdit):
         self._neditable = neditable
         #Config Editor
         self.set_flags()
-        self.__lines_count = None
         self.lang = 'python'
         self._last_block_position = 0
         self.__lines_count = 0


### PR DESCRIPTION
Fix editor by removing pointless variable reassignment on contiguous lines,

https://github.com/ninja-ide/ninja-ide/blob/master/ninja_ide/gui/editor/editor.py#L100     

``` python
 self.__lines_count = None  
```

y dos lineas despues

``` python
self.__lines_count = 0
```

Brancho: fix/editor  :yum: 
