### PR TITLE
Fix bug where suggested paths and all found dirs are the same list

### DIFF
--- a/ninja_ide/core/settings.py
+++ b/ninja_ide/core/settings.py
@@ -56,7 +56,8 @@ def detect_python_path():
     if (IS_WINDOWS and PYTHON_EXEC_CONFIGURED_BY_USER) or not IS_WINDOWS:
         return []
 
-    suggested = dirs = []
+    suggested = []
+    dirs = []
     try:
         drives = [QDir.toNativeSeparators(d.absolutePath())
                   for d in QDir.drives()]


### PR DESCRIPTION
Bug: The suggested python paths show all dirs instead of just the suggested ones because they both reference the same list object.

Fix: Create separate list instances for `suggested` and `dirs`.
