### PR TITLE
Fix settings.PYTHON_PATH undefined.

### DIFF
--- a/ninja_ide/gui/dialogs/python_detect_dialog.py
+++ b/ninja_ide/gui/dialogs/python_detect_dialog.py
@@ -70,6 +70,7 @@ class PythonDetectDialog(QDialog):
         python_path = self.listPaths.currentItem().text()
 
         qsettings = QSettings(resources.SETTINGS_PATH, QSettings.IniFormat)
+        settings.PYTHON_PATH = python_path
         settings.PYTHON_EXEC = python_path
         settings.PYTHON_EXEC_CONFIGURED_BY_USER = True
         qsettings.setValue('preferences/execution/pythonPath', python_path)


### PR DESCRIPTION
Fixes error:

```
    tool_path = os.path.join(os.path.dirname(settings.PYTHON_PATH),
AttributeError: 'module' object has no attribute 'PYTHON_PATH'
```
