### PR TITLE
suggestion to release Ninja-IDE under GPLv3+ instead of simply GPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ http://ninja-ide.github.io/ninja-ide
 
 ## License
 
--   GPL v3
+-   GPLv3+ (GPLv3 or any other version later published by FSF at your option)

--- a/ninja_ide/core/template_registry/ntemplate_registry.py
+++ b/ninja_ide/core/template_registry/ntemplate_registry.py
@@ -86,7 +86,7 @@ class BaseProjectType(QObject):
     single_line_comment = {}
     description = "No Description"
 
-    def __init__(self, name, path, licence_text, licence_short_name="GPLv2",
+    def __init__(self, name, path, licence_text, licence_short_name="GPLv3",
                  base_encoding="utf-8"):
         self.name = name
         self.path = path

--- a/ninja_ide/gui/qml/StartPage.qml
+++ b/ninja_ide/gui/qml/StartPage.qml
@@ -180,7 +180,7 @@ Rectangle {
         anchors.bottomMargin: 10
         font.pixelSize: 12
         color: "white"
-        text: "Copyright © 2011-2014 NINJA-IDE under GPLv3 License agreements"
+        text: "Copyright © 2011-2014 NINJA-IDE is distributed under the terms of the GNU GPLv3+ copyleft license"
     }
 
     function add_project(name, path, favorite){


### PR DESCRIPTION
I had the chance to talk to Diego Sarmentero a few days ago regarding the possibility of switching from simply GNU GPLv3 to GNU GPLv3+. Though for most people this switch does not change much (if any change is made at all), what it really means is of extreme importance to guarantee software freedom.

Every once in a while, new threats to software freedom arise and if they are of any harm or not comes from the fact that the current version of the software license is not effective enough against such threats. In these cases, the need of writing a new license emerges consequently making it incompatible with the previous software license, in order to enforce mechanisms to protect our freedom against the new threats.

If your software is simply GNU GPLvX (which was the case of Ninja-ide, GNU GPLv3) you will not be able to use any GNU GPLvX+i (GNU GPLv4, let's say) code in the source code of ninja-ide and neither will the project released under the terms of GNU GPLv4. In order to avoid such an inconvenient, it is strongly suggested to add the plus "+" that basically means "or any other new version of this license published by the FSF at your option".

I tried not to write a huge comment, but I'm not sure if I made it. More details can be found at https://mribeirodantas.github.io/GNUGPLvX+.html

Best regards,
