### PR TITLE
[QSS] Fix QSplitter, makes QSplitter Visible

### DIFF
--- a/ninja_ide/extensions/theme/ninja_dark.qss
+++ b/ninja_ide/extensions/theme/ninja_dark.qss
@@ -464,6 +464,7 @@ QComboBox#combo_symbols::drop-down {
 QComboBox::down-arrow,
 QComboBox#combotab::down-arrow,
 QComboBox#combo_symbols::down-arrow {
+     image: url(:img/chevron);
      top: 2px;
      right: 7px;
 }


### PR DESCRIPTION
- QSS Only fix.
- Fix QSplitter.
- Makes QSplitter visible with default theme so you can see and drag it.

![temp](https://cloud.githubusercontent.com/assets/1189414/3020971/045e4f2c-dfa8-11e3-8713-9c6a8aafe956.jpg)

Branch: fix/qsplitter
