### PR TITLE
[ToolBar] Add Center Items in ToolBar option

### DIFF
--- a/ninja_ide/core/settings.py
+++ b/ninja_ide/core/settings.py
@@ -93,7 +93,7 @@ LANGUAGE = EXECUTION_OPTIONS = ""
 
 SHOW_START_PAGE = CONFIRM_EXIT = SHOW_STATUS_NOTIFICATIONS = True
 
-HIDE_TOOLBAR = PYTHON_EXEC_CONFIGURED_BY_USER = False
+HIDE_TOOLBAR = TOOLBAR_POSITION = PYTHON_EXEC_CONFIGURED_BY_USER = False
 
 NOTIFICATION_COLOR = "#000"
 
@@ -410,6 +410,7 @@ def load_settings():
     global NOTIFICATION_POSITION
     global NOTIFICATION_COLOR
     global LAST_CLEAN_LOCATOR
+    global TOOLBAR_POSITION
     #General
     HIDE_TOOLBAR = qsettings.value("window/hide_toolbar", False, type=bool)
     SHOW_STATUS_NOTIFICATIONS = qsettings.value(
@@ -557,6 +558,8 @@ def load_settings():
         'preferences/general/notification_color', "#000", type='QString')
     LAST_CLEAN_LOCATOR = qsettings.value(
         'preferences/general/cleanLocator', None)
+    TOOLBAR_POSITION =  qsettings.value(
+        'preferences/general/toolbar_position', False, type=bool)
     from ninja_ide.extensions import handlers
     handlers.init_basic_handlers()
     clean_locator_db(qsettings)

--- a/ninja_ide/gui/dialogs/preferences/preferences_general.py
+++ b/ninja_ide/gui/dialogs/preferences/preferences_general.py
@@ -56,6 +56,7 @@ class GeneralConfiguration(QWidget):
         groupBoxWorkspace = QGroupBox(
             translations.TR_PREFERENCES_GENERAL_WORKSPACE)
         groupBoxNoti = QGroupBox(translations.TR_NOTIFICATION)
+        groupBoxToolBar = QGroupBox(translations.TR_TOOLBAR)
         groupBoxReset = QGroupBox(translations.TR_PREFERENCES_GENERAL_RESET)
 
         #Start
@@ -110,6 +111,10 @@ class GeneralConfiguration(QWidget):
         hboxNoti.addWidget(self._notify_position)
         hboxNoti.addWidget(self._notify_color, 0, Qt.AlignRight)
 
+        # ToolBar
+        self._toolbar_center = QCheckBox(translations.TR_CENTER_ITEMS_IN_TOOLBAR)
+        QHBoxLayout(groupBoxToolBar).addWidget(self._toolbar_center)
+
         # Resetting preferences
         vboxReset = QVBoxLayout(groupBoxReset)
         self._btnReset = QPushButton(
@@ -133,6 +138,7 @@ class GeneralConfiguration(QWidget):
         extensions = ', '.join(settings.SUPPORTED_EXTENSIONS)
         self._txtExtensions.setText(extensions)
         self._notify_position.setCurrentIndex(settings.NOTIFICATION_POSITION)
+        self._toolbar_center.setCheckState(settings.TOOLBAR_POSITION)
         qsettings.endGroup()
         qsettings.endGroup()
 
@@ -140,6 +146,7 @@ class GeneralConfiguration(QWidget):
         vbox.addWidget(groupBoxClose)
         vbox.addWidget(groupBoxWorkspace)
         vbox.addWidget(groupBoxNoti)
+        vbox.addWidget(groupBoxToolBar)
         vbox.addWidget(groupBoxReset)
 
         #Signals
@@ -197,6 +204,9 @@ class GeneralConfiguration(QWidget):
         settings.NOTIFICATION_COLOR = self._notification_choosed_color
         qsettings.setValue('preferences/general/notification_color',
             settings.NOTIFICATION_COLOR)
+        settings.TOOLBAR_POSITION = self._toolbar_center.isChecked()
+        qsettings.setValue('preferences/general/toolbar_position',
+                           settings.TOOLBAR_POSITION)
 
     def _reset_preferences(self):
         """Method to Reset all Preferences to default values"""

--- a/ninja_ide/gui/menus/menubar.py
+++ b/ninja_ide/gui/menus/menubar.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from PyQt4.QtGui import QAction
-from PyQt4.QtGui import QMenu
+from PyQt4.QtGui import QMenu, QSizePolicy, QWidget
 from PyQt4.QtCore import QObject
 from collections import defaultdict
 
@@ -153,11 +153,17 @@ class _MenuBar(QObject):
                     #ADD A LATER CALLBACK
 
     def load_toolbar(self, ide):
+        """Take an IDE instance and load its ToolBar items."""
         toolbar = ide.get_service("toolbar")
         toolbar.clear()
         toolbar_items = ide.get_toolbaritems()
-        categories = list(ide.get_bar_categories().items())
+        categories = tuple(ide.get_bar_categories().items())
         categories = sorted(categories, key=lambda x: x[1])
+        if settings.TOOLBAR_POSITION:  # QToolBar with Centered items
+            l_spacer, r_spacer = QWidget(), QWidget()
+            l_spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+            r_spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+            toolbar.addWidget(l_spacer)
         for category, _ in categories:
             items_in_category = sorted(
                 [(key, toolbar_items[key][0], toolbar_items[key][1])
@@ -170,6 +176,8 @@ class _MenuBar(QObject):
                     toolbar.addAction(action)
             if items_in_category:
                 toolbar.addSeparator()
+        if settings.TOOLBAR_POSITION:
+            toolbar.addWidget(r_spacer)
 
 
 menu = _MenuBar()

--- a/ninja_ide/translations.py
+++ b/ninja_ide/translations.py
@@ -660,3 +660,6 @@ TR_SCHEME_INVALID_NAME = tr(
     "\nPlease pick a different name.")
 TR_WANT_OVERWRITE_FILE = tr("NINJA-IDE", "Do you want to overwrite the file")
 TR_SCHEME_SAVED = tr("NINJA-IDE", "The scheme has been saved")
+
+TR_CENTER_ITEMS_IN_TOOLBAR = tr("NINJA-IDE", "Center items in Toolbar")
+TR_TOOLBAR = tr("NINJA-IDE", "Toolbar")


### PR DESCRIPTION
- Add Center Items in ToolBar option (nice for Big screen resolutions).
- Update Translations.
- Add QCheckbox in Preferences general (defaults to False).
- Works OK on Horizontal position.

![temp](https://cloud.githubusercontent.com/assets/1189414/3021760/82de62e0-dfb9-11e3-9414-b6de2ce3f24a.jpg)

Brancho:  feature/center_toolbar  :octocat: 
