### PR TITLE
[error panel] Add Hide Disabled Error list on Errors side panel

### DIFF
--- a/ninja_ide/gui/editor/checkers/errors_lists.py
+++ b/ninja_ide/gui/editor/checkers/errors_lists.py
@@ -99,8 +99,10 @@ class ErrorsWidget(QDialog):
         settings.FIND_ERRORS = not settings.FIND_ERRORS
         if settings.FIND_ERRORS:
             self.btn_lint_activate.setText(self.tr("Lint: ON"))
+            self.listErrors.show()
         else:
             self.btn_lint_activate.setText(self.tr("Lint: OFF"))
+            self.listErrors.hide()
         self.emit(SIGNAL("lintActivated(bool)"), settings.FIND_ERRORS)
 
     def _turn_on_off_pep8(self):
@@ -108,8 +110,10 @@ class ErrorsWidget(QDialog):
         settings.CHECK_STYLE = not settings.CHECK_STYLE
         if settings.CHECK_STYLE:
             self.btn_pep8_activate.setText(self.tr("PEP8: ON"))
+            self.listPep8.show()
         else:
             self.btn_pep8_activate.setText(self.tr("PEP8: OFF"))
+            self.listPep8.hide()
         self.emit(SIGNAL("pep8Activated(bool)"), settings.CHECK_STYLE)
 
     def errors_selected(self):


### PR DESCRIPTION
- Add Hide Disabled Error list on Errors side panel.
- Add Show Enabled Error list on Errors side panel.
- 4 Lines diff  :)

**Before:**
- I got 34783823 Lint errors I care of, but 0 PEP8 errors that I dont care.
- I Disable PEP8 on the Errors Panel.
- At any Screen Resolution it still using >50% screen space on the Errors panel, and its Empty !.

**After:**
- I got 34783823 Lint errors I care of, but 0 PEP8 errors that I dont care.
- I Disable PEP8 on the Errors Panel.
- At any Screen Resolution Lint Errors uses all available space on the Errors panel.
- PEP8 Empty Disabled error list is hidden freeing up space, the same applies for reverse case.

Brancho:  feature/hide_disabled_error_panel
