### PR TITLE
[WebRender] Fix WebRender, Enable HTML5 settings

### DIFF
--- a/ninja_ide/gui/tools_dock/web_render.py
+++ b/ninja_ide/gui/tools_dock/web_render.py
@@ -16,6 +16,8 @@
 # along with NINJA-IDE; If not, see <http://www.gnu.org/licenses/>.
 from __future__ import absolute_import
 
+from tempfile import mkdtemp
+
 from PyQt4.QtGui import QWidget
 from PyQt4.QtGui import QVBoxLayout
 from PyQt4.QtWebKit import QWebView
@@ -29,12 +31,29 @@ class WebRender(QWidget):
 
     def __init__(self):
         super(WebRender, self).__init__()
-
-        vbox = QVBoxLayout(self)
-        #Web Frame
-        self.webFrame = QWebView()
-        QWebSettings.globalSettings().setAttribute(
-            QWebSettings.DeveloperExtrasEnabled, True)
+        vbox, temporary_directory = QVBoxLayout(self), mkdtemp()
+        # Web Frame
+        self.webFrame = QWebView()  # QWebView = QWebFrame + QWebSettings
+        self.webFrame.setStyleSheet("QWebView{ background:#fff }")  # no dark bg
+        settings = self.webFrame.settings()  # QWebSettings instance
+        settings.setDefaultTextEncoding("utf-8")
+        settings.setIconDatabasePath(temporary_directory)
+        settings.setLocalStoragePath(temporary_directory)
+        settings.setOfflineStoragePath(temporary_directory)
+        settings.setOfflineWebApplicationCachePath(temporary_directory)
+        settings.setAttribute(QWebSettings.DeveloperExtrasEnabled, True)
+        settings.setAttribute(QWebSettings.LocalStorageEnabled, True)
+        settings.setAttribute(QWebSettings.OfflineStorageDatabaseEnabled, True)
+        settings.setAttribute(QWebSettings.PluginsEnabled, True)
+        settings.setAttribute(QWebSettings.DnsPrefetchEnabled, True)
+        settings.setAttribute(QWebSettings.JavascriptCanOpenWindows, True)
+        settings.setAttribute(QWebSettings.JavascriptCanCloseWindows, True)
+        settings.setAttribute(QWebSettings.JavascriptCanAccessClipboard, True)
+        settings.setAttribute(QWebSettings.SpatialNavigationEnabled, True)
+        settings.setAttribute(
+            QWebSettings.LocalContentCanAccessRemoteUrls, True)
+        settings.setAttribute(
+            QWebSettings.OfflineWebApplicationCacheEnabled, True)
         vbox.addWidget(self.webFrame)
 
     def render_page(self, url):


### PR DESCRIPTION
- Fix WebRender to use non-Dark (black) background by default.
- Enable HTML5 settings.

![temp](https://cloud.githubusercontent.com/assets/1189414/3138058/6810aabc-e86b-11e3-8ab9-827b67a439a1.jpg)

Branch:  fix/webrender
