### PR TITLE
fixes python_syntax import

### DIFF
--- a/ninja_ide/gui/tools_dock/console_widget.py
+++ b/ninja_ide/gui/tools_dock/console_widget.py
@@ -38,7 +38,7 @@ from ninja_ide.core import settings
 from ninja_ide.tools import console
 from ninja_ide.gui.ide import IDE
 from ninja_ide.gui.editor import syntax_highlighter
-from ninja_ide.gui.editor import python_syntax
+from ninja_ide.gui.editor.syntaxes import python_syntax
 #from ninja_ide.tools.completion import completer
 #from ninja_ide.tools.completion import completer_widget
 


### PR DESCRIPTION
Executing "python ninja-ide.py":

Traceback (most recent call last):
  File "ninja-ide.py", line 34, in <module>
    ninja_ide.setup_and_run()
  File "~/ninja-ide/ninja_ide/**init**.py", line 72, in setup_and_run
    core.run_ninja()
  File "~/ninja-ide/ninja_ide/core/core.py", line 55, in run_ninja
    from ninja_ide import gui
  File "~/ninja-ide/ninja_ide/gui/**init**.py", line 41, in <module>
    import ninja_ide.gui.tools_dock.tools_dock
  File "~/ninja-ide/ninja_ide/gui/tools_dock/tools_dock.py", line 40, in <module>
    from ninja_ide.gui.tools_dock import console_widget
  File "~/ninja-ide/ninja_ide/gui/tools_dock/console_widget.py", line 41, in <module>
    from ninja_ide.gui.editor import python_syntax
ImportError: cannot import name python_syntax

I suposse "python_syntax.py" was moved recently to syntaxes folder.
