### PR TITLE
Fix for "Find Usages" menu item in code editor

### DIFF
--- a/ninja_ide/translations.py
+++ b/ninja_ide/translations.py
@@ -262,7 +262,10 @@ TR_FILE_MODIFIED_OUTSIDE = tr(
     "NINJA-IDE",
     "\nThe file has been modified outside the application\n"
     "Do you want to reload it?")
-
+TR_WARNING_MESSAGE_ADD_TO_PROJECT = tr(
+    "NINJA-IDE",
+    "You should add this file to project before using this function")
+TR_WARNING_MESSAGE_TITLE = tr("NINJA_IDE", "Ninja warns you!")
 
 # tools_dock
 TR_TEXT_FOR_REPLACE = tr("NINJA-IDE", "Text to Replace")


### PR DESCRIPTION
Hello :)

I've encountered a problem with "Find Usages" menu item in context menu of code editor.
# How to recreate problem
1. Create new blank (not saved) file
2. Write some content
3. Use "Find Usages" on any word.
4. Error:
   Traceback (most recent call last):
   File "/xxx/ninja-ide/ninja_ide/gui/tools_dock/tools_dock.py", line 163, in show_find_occurrences
     self._findInFilesWidget.find_occurrences(word)
   File "/xxx/ninja-ide/ninja_ide/gui/tools_dock/find_in_files.py", line 507, in find_occurrences
     self._find_widget.dir_combo.addItem(nproject.path)
   AttributeError: 'NoneType' object has no attribute 'path'

My patch fixes it and gives user additional information on how to use "Find Usages".
