### PR TITLE
The variable name of settings.PYTHON_PATH was incorrect, 

### DIFF
--- a/ninja_ide/gui/editor/checkers/migration_2to3.py
+++ b/ninja_ide/gui/editor/checkers/migration_2to3.py
@@ -43,9 +43,9 @@ class MigrationTo3(QThread):
         self.dirty = False
         self.checks = {}
         if settings.IS_WINDOWS and settings.PYTHON_EXEC_CONFIGURED_BY_USER:
-            tool_path = os.path.join(os.path.dirname(settings.PYTHON_PATH),
+            tool_path = os.path.join(os.path.dirname(settings.PYTHON_EXEC),
                                      'Tools', 'Scripts', '2to3.py')
-            self._command = [settings.PYTHON_PATH, tool_path]
+            self._command = [settings.PYTHON_EXEC, tool_path]
         else:
             self._command = ['2to3']
 


### PR DESCRIPTION
The name was changed to settings.PYTHON_EXEC. Run and tested in Windows 8 with python 2.7. 
