### PR TITLE
Fix Python Dialog appearing on every startup. 

### DIFF
--- a/ninja_ide/gui/dialogs/python_detect_dialog.py
+++ b/ninja_ide/gui/dialogs/python_detect_dialog.py
@@ -41,10 +41,10 @@ class PythonDetectDialog(QDialog):
         self.setWindowTitle("Configure Python Path")
 
         vbox = QVBoxLayout(self)
-
-        lblMessage = QLabel(self.tr("We have detected that you are using " +
-            "Windows,\nplease choose the proper " +
-            "Python application for you:"))
+        msg_str = ("We have detected that you are using "
+                   "Windows,\nplease choose the proper "
+                   "Python application for you:")
+        lblMessage = QLabel(self.tr(msg_str))
         vbox.addWidget(lblMessage)
 
         self.listPaths = QListWidget()
@@ -73,6 +73,6 @@ class PythonDetectDialog(QDialog):
         settings.PYTHON_PATH = python_path
         settings.PYTHON_EXEC = python_path
         settings.PYTHON_EXEC_CONFIGURED_BY_USER = True
-        qsettings.setValue('preferences/execution/pythonPath', python_path)
-        qsettings.setValue('preferences/execution/pythonPathConfigured', True)
+        qsettings.setValue('preferences/execution/pythonExec', python_path)
+        qsettings.setValue('preferences/execution/pythonExecConfigured', True)
         self.close()


### PR DESCRIPTION
The dialog to choose the python program was appearing
on every startup of ninja-ide in Windows. I changed the name of
settings variable to point to the correct one.

I see that the issue #1741 is fixed but I still seeing this in Windows, 

Also a change to the string format was added to keep the
RefactoringTool happy.
