### PR TITLE
Some fixes

### DIFF
--- a/ninja_ide/tools/console.py
+++ b/ninja_ide/tools/console.py
@@ -36,10 +36,9 @@ class Cache(object):
 
     def flush(self):
         """Join together all the outputs and return it to be displayed."""
-        if len(self.out) > 1:
-            output = ''.join(self.out)[:-1]
-            self.reset()
-            return output
+        output = ''.join(self.out)[:-1]
+        self.reset()
+        return output
 
 
 class ExitWrapper(object):

--- a/ninja_ide/tools/locator/locator.py
+++ b/ninja_ide/tools/locator/locator.py
@@ -366,7 +366,7 @@ class LocateSymbolsThread(QThread):
         mtime = int(os.stat(file_path).st_mtime)
         if data is not None and (mtime == int(data[1])):
             try:
-                results = pickle.loads(str(data[2]))
+                results = pickle.loads(data[2])
                 mapping_symbols[file_path] += results
                 return
             except:


### PR DESCRIPTION
* Fixed ''str' does not support the buffer interface' (locator) on Python 3
* Fixed flush in console. Now supports Python 2.x and Python 3.x