### PR TITLE
add a pkgver() function to the PKGBUILD

### DIFF
--- a/build_files/PKGBUILD
+++ b/build_files/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Federico Cinelli <cinelli.federico@gmail.com>
 
 pkgname=ninja-ide-git
-pkgver=20180310
+pkgver=20180317
 pkgrel=1
 pkgdesc="Cross-platform IDE focused on Python application development - latest git pull"
 arch=('any')
@@ -29,6 +29,11 @@ prepare() {
   fi
 
   msg "GIT checkout done or server timeout"
+}
+
+pkgver() {
+  cd $startdir/$_gitname
+  git log -1 --date=short --pretty=format:%ad | sed 's/-//g'
 }
 
 package() {


### PR DESCRIPTION
since prepare() is executed before pkgver() we can use the date from git

There exists the author date (17 march for current master)
and the commit date (21 march for current master)

I used the author date to eventually avoid confusing, it's the date which is shown with git-log. Tell me if you prefer otherwise.