### PR TITLE
Issue #2039: Hiding 'Langauge Manager' menu

### DIFF
--- a/ninja_ide/gui/actions.py
+++ b/ninja_ide/gui/actions.py
@@ -129,14 +129,14 @@ ACTIONS_GENERAL = (
         },
         "connect": "show_schemes"
     },
-    {
-        "action": {
-            "text": translations.TR_LANGUAGE_MANAGER,
-            "section": (translations.TR_MENU_EXTENSIONS, None),
-            "weight": 120
-        },
-        "connect": "show_languages"
-    },
+    #{
+    #    "action": {
+    #        "text": translations.TR_LANGUAGE_MANAGER,
+    #        "section": (translations.TR_MENU_EXTENSIONS, None),
+    #        "weight": 120
+    #    },
+    #    "connect": "show_languages"
+    #},
     {
         "action": {
             "text": translations.TR_ABOUT_NINJA,


### PR DESCRIPTION
To hide the "language Manager' menu, as a workaround suggested by eamanu