### PR TITLE
Fix HDPI scaling must be set before QCoreApplication

### DIFF
--- a/ninja_ide/core/core.py
+++ b/ninja_ide/core/core.py
@@ -46,19 +46,22 @@ def run_ninja():
             print("The process couldn't be renamed'")
     filenames, projects_path, extra_plugins, linenos, log_level, log_file = \
         cliparser.parse()
+    
     # Create the QApplication object before using the
     # Qt modules to avoid warnings
+    from ninja_ide.core import settings
+    QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling, settings.HDPI)
+    
     app = QApplication(sys.argv)
     from ninja_ide import resources
-    from ninja_ide.core import settings
     resources.create_home_dir_structure()
+
     # Load Logger
     from ninja_ide.tools.logger import NinjaLogger
     NinjaLogger.argparse(log_level, log_file)
 
     # Load Settings
     settings.load_settings()
-    QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling, settings.HDPI)
     if settings.CUSTOM_SCREEN_RESOLUTION:
         os.environ["QT_SCALE_FACTOR"] = settings.CUSTOM_SCREEN_RESOLUTION
     from ninja_ide import ninja_style


### PR DESCRIPTION
`Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.` has been fixed.