### PR TITLE
Quick fixes to get Ninja to launch on modern Python (#2146)

### DIFF
--- a/ninja_ide/gui/central_widget.py
+++ b/ninja_ide/gui/central_widget.py
@@ -140,8 +140,7 @@ class CentralWidget(QWidget):
         lateral_visible = qsettings.value(
             "window/central/lateral_visible", True, type=bool)
         if height_size is None:
-            self._splitter_inside.setSizes([(self.height() / 3) * 2,
-                                           self.height() / 3])
+            self._splitter_inside.setSizes([(self.height() // 3) * 2, self.height() // 3])
         else:
             self._splitter_inside.restoreState(height_size)
         if width_size is None:

--- a/ninja_ide/gui/editor/base.py
+++ b/ninja_ide/gui/editor/base.py
@@ -48,7 +48,7 @@ class BaseTextEditor(QPlainTextEdit):
         """Get or set the current cursor position"""
 
         cursor = self.textCursor()
-        return (cursor.blockNumber(), cursor.columnNumber())
+        return cursor.blockNumber(), cursor.columnNumber()
 
     @cursor_position.setter
     def cursor_position(self, position):
@@ -56,8 +56,7 @@ class BaseTextEditor(QPlainTextEdit):
         line = min(line, self.line_count() - 1)
         column = min(column, len(self.line_text(line)))
         cursor = QTextCursor(self.document().findBlockByNumber(line))
-        cursor.setPosition(cursor.block().position() + column,
-                           QTextCursor.MoveAnchor)
+        cursor.setPosition(cursor.block().position() + column, QTextCursor.MoveAnchor)
         self.setTextCursor(cursor)
 
     @property
@@ -281,8 +280,7 @@ class CodeEditor(BaseTextEditor):
 
         block = self.firstVisibleBlock()
         block_number = block.blockNumber()
-        top = self.blockBoundingGeometry(block).translated(
-            self.contentOffset()).top()
+        top = self.blockBoundingGeometry(block).translated(self.contentOffset()).top()
         bottom = top + self.blockBoundingRect(block).height()
         editor_height = self.height()
         while block.isValid():
@@ -290,7 +288,8 @@ class CodeEditor(BaseTextEditor):
             if not visible:
                 break
             if block.isVisible():
-                append((top, block_number, block))
+                # These are consumed as int:
+                append((int(top), int(block_number), block))
             block = block.next()
             top = bottom
             bottom = top + self.blockBoundingRect(block).height()

--- a/ninja_ide/gui/editor/base_editor.py
+++ b/ninja_ide/gui/editor/base_editor.py
@@ -105,8 +105,7 @@ class BaseEditor(QPlainTextEdit, EditorMixin):
         palette.setColor(palette.Base, self._background_color)
         palette.setColor(palette.Text, self._foreground_color)
         palette.setColor(palette.HighlightedText, self._selection_color)
-        palette.setColor(palette.Highlight,
-                         self._selection_background_color)
+        palette.setColor(palette.Highlight, self._selection_background_color)
         self.setPalette(palette)
 
     def paintEvent(self, event):
@@ -130,7 +129,7 @@ class BaseEditor(QPlainTextEdit, EditorMixin):
             if not visible:
                 break
             if block.isVisible():
-                append((top, block_number, block))
+                append((int(top), int(block_number), block))
             block = block.next()
             top = bottom
             bottom = top + self.blockBoundingRect(block).height()

--- a/ninja_ide/gui/editor/extensions/__init__.py
+++ b/ninja_ide/gui/editor/extensions/__init__.py
@@ -15,7 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with NINJA-IDE; If not, see <http://www.gnu.org/licenses/>.
 import os
-import imp
+import importlib
+import importlib.machinery
+
 from ninja_ide import resources
 
 
@@ -74,11 +76,12 @@ class Extension(metaclass=ExtensionRegistry):
 
 
 def discover_all(extensions_dir='.'):
-    extensions_dir = os.path.join(resources.PRJ_PATH,
-                                  "gui", "editor", "extensions")
+    extensions_dir = os.path.join(resources.PRJ_PATH, "gui", "editor", "extensions")
     for filename in os.listdir(extensions_dir):
         module_name, ext = os.path.splitext(filename)
         if ext == '.py' and not filename.startswith('__'):
-            _file, path, descr = imp.find_module(module_name, [extensions_dir])
+            # _file, path, descr = imp.find_module(module_name, [extensions_dir])
+            _file, path, descr = importlib.machinery.PathFinder().find_spec(module_name, [extensions_dir])
             if _file:
-                imp.load_module(module_name, _file, path, descr)
+                loader = importlib.machinery.SourceFileLoader(module_name, filename)
+                loader.load_module()

--- a/ninja_ide/gui/editor/extensions/margin_line.py
+++ b/ninja_ide/gui/editor/extensions/margin_line.py
@@ -85,7 +85,7 @@ class RightMargin(base.Extension):
         metrics = QFontMetricsF(self._neditor.font())
         doc_margin = self._neditor.document().documentMargin()
         offset = self._neditor.contentOffset().x() + doc_margin
-        x = round(metrics.width(' ') * self.__position) + offset
+        x = round(metrics.width(' ') * self.__position) + int(offset)
         if self.__background:
             width = self._neditor.viewport().width() - x
             rect = QRect(x, 0, width, self._neditor.height())

--- a/ninja_ide/gui/editor/highlighter.py
+++ b/ninja_ide/gui/editor/highlighter.py
@@ -316,7 +316,8 @@ def build_highlighter(language, force=False):
         scanners = {}
         for scanner in syntax_structure.get("scanner"):
             name = scanner.get("partition_name")
-            scanners[name] = Scanner(scanner.get("tokens"))
+            # TODO: fix Scanner `re` issue
+            # scanners[name] = Scanner(scanner.get("tokens"))
         syntax = Syntax(part_scanner, scanners)
         syntax.build_context()
         syntax_registry.register_syntax(language, syntax)

--- a/ninja_ide/gui/editor/neditable.py
+++ b/ninja_ide/gui/editor/neditable.py
@@ -229,5 +229,5 @@ class NEditable(QObject):
         for items in self.registered_checkers:
             checker, _, _ = items
             func = getattr(checker, 'refresh_display', None)
-            if isinstance(func, collections.Callable):
+            if isinstance(func, collections.abc.Callable):
                 func()

--- a/ninja_ide/gui/editor/scrollbar.py
+++ b/ninja_ide/gui/editor/scrollbar.py
@@ -62,18 +62,17 @@ class ScrollBarOverlay(QWidget):
         rect = self._nscrollbar.overlay_rect()
         sb_range = self._nscrollbar.get_scrollbar_range()
         sb_range = max(self.visible_range, sb_range)
-        result_width = rect.width() / 3
+        result_width = rect.width() // 3
         result_height = min(rect.height() / sb_range + 1, 4)
         x = rect.center().x() - 1
-        offset = rect.height() / sb_range * self.range_offset
-        vertical_margin = ((rect.height() / sb_range) - result_height) / 2
+        offset = rect.height() // sb_range * self.range_offset
+        vertical_margin = ((rect.height() / sb_range) - result_height) // 2
 
         painter = QPainter(self)
 
         for lineno in self.cache.keys():
             marker = self.cache[lineno]
-            top = rect.top() + offset + vertical_margin + \
-                marker.position / sb_range * rect.height()
+            top = int(rect.top() + offset + vertical_margin + marker.position / sb_range * rect.height())
             painter.fillRect(
                 x,
                 top,

--- a/ninja_ide/gui/editor/side_area/line_number_widget.py
+++ b/ninja_ide/gui/editor/side_area/line_number_widget.py
@@ -61,15 +61,12 @@ class LineNumberWidget(side_area.SideWidget):
         # Draw visible blocks
         for top, line, block in self._neditor.visible_blocks:
             # Set bold to current line and selected lines
-            if ((has_sel and sel_start <= line <= sel_end) or
-                    (not has_sel and current_line == line)):
-                painter.fillRect(
-                    QRect(0, top, self.width(), height), self._color_selected)
+            if (has_sel and sel_start <= line <= sel_end) or (not has_sel and current_line == line):
+                painter.fillRect(QRect(0, top, self.width(), height), self._color_selected)
             else:
                 painter.setPen(pen)
                 painter.setFont(font)
-            painter.drawText(self.LEFT_MARGIN, top, width, height,
-                             Qt.AlignRight, str(line + 1))
+            painter.drawText(self.LEFT_MARGIN, top, width, height, Qt.AlignRight, str(line + 1))
 
     def __calculate_width(self):
         digits = len(str(max(1, self._neditor.blockCount())))

--- a/ninja_ide/gui/explorer/explorer_container.py
+++ b/ninja_ide/gui/explorer/explorer_container.py
@@ -200,7 +200,7 @@ class ExplorerContainer(dynamic_splitter.DynamicSplitter):
         else:
             self.widget(widget_index).addTab(obj, tabname)
         func = getattr(obj, 'install_tab', None)
-        if isinstance(func, collections.Callable):
+        if isinstance(func, collections.abc.Callable):
             func()
 
     def rotate_tab_position(self):

--- a/ninja_ide/gui/ide.py
+++ b/ninja_ide/gui/ide.py
@@ -246,7 +246,7 @@ class IDE(QMainWindow):
 
         obj = IDE.__IDESERVICES.get(service_name, None)
         func = getattr(obj, 'install', None)
-        if isinstance(func, collections.Callable):
+        if isinstance(func, collections.abc.Callable):
             func()
         self._connect_signals()
 
@@ -282,7 +282,7 @@ class IDE(QMainWindow):
                     connection['target'], None)
                 slot = connection['slot']
                 signal_name = connection['signal_name']
-                if target and isinstance(slot, collections.Callable):
+                if target and isinstance(slot, collections.abc.Callable):
                     # FIXME:
                     sl = getattr(target, signal_name, None)
 

--- a/ninja_ide/gui/main_panel/combo_editor.py
+++ b/ninja_ide/gui/main_panel/combo_editor.py
@@ -497,14 +497,12 @@ class ActionBar(QFrame):
         self.lbl_position = QLabel()
         self.lbl_position.setObjectName("position")
         self.lbl_position.setText(self._pos_text % (0, 0))
-        margin = self.style().pixelMetric(
-            QStyle.PM_LayoutHorizontalSpacing) / 2
+        margin = self.style().pixelMetric(QStyle.PM_LayoutHorizontalSpacing) // 2
         self.lbl_position.setContentsMargins(margin, 0, margin, 0)
         self.lbl_position.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         hbox.addWidget(self.lbl_position)
         self.btn_close = QPushButton()
-        self.btn_close.setIcon(
-            self.style().standardIcon(QStyle.SP_DialogCloseButton))
+        self.btn_close.setIcon(self.style().standardIcon(QStyle.SP_DialogCloseButton))
 
         if main_combo:
             self.btn_close.setObjectName('close_button_combo')

--- a/ninja_ide/gui/tools_dock/tools_dock.py
+++ b/ninja_ide/gui/tools_dock/tools_dock.py
@@ -228,7 +228,7 @@ class _ToolsDock(QWidget):
     def add_widget(self, display_name, obj):
         self._stack_widgets.addWidget(obj)
         func = getattr(obj, "install_widget", None)
-        if isinstance(func, collections.Callable):
+        if isinstance(func, collections.abc.Callable):
             func()
 
     def on_button_triggered(self):
@@ -350,25 +350,17 @@ class ToolButton(QPushButton):
         if self._number is None:
             painter = QPainter(self)
             fm = self.fontMetrics()
-            base_line = (self.height() - fm.height()) / 2 + fm.ascent()
             painter.drawText(event.rect(), Qt.AlignCenter, self._text)
         else:
             fm = self.fontMetrics()
-            base_line = (self.height() - fm.height()) / 2 + fm.ascent()
+            base_line = (self.height() - fm.height()) // 2 + fm.ascent()
             number_width = fm.width(self._number)
 
             painter = QPainter(self)
             # Draw shortcut number
-            painter.drawText(
-                (15 - number_width) / 2,
-                base_line,
-                self._number
-            )
+            painter.drawText((15 - number_width) // 2, base_line, self._number)
             # Draw display name of tool button
-            painter.drawText(
-                18,
-                base_line,
-                fm.elidedText(self._text, Qt.ElideRight, self.width()))
+            painter.drawText(18, base_line, fm.elidedText(self._text, Qt.ElideRight, self.width()))
 
     def sizeHint(self):
         self.ensurePolished()

--- a/ninja_ide/intellisensei/intellisense_registry.py
+++ b/ninja_ide/intellisensei/intellisense_registry.py
@@ -18,7 +18,7 @@
 import time
 import abc
 from collections import namedtuple
-from collections import Callable
+from collections.abc import Callable
 
 from PyQt5.QtCore import QObject
 from PyQt5.QtCore import QThread

--- a/ninja_ide/tools/ui_tools.py
+++ b/ninja_ide/tools/ui_tools.py
@@ -900,7 +900,7 @@ def install_shortcuts(obj, actions, ide):
                     continue
                 shortcut = QShortcut(short(short_key), ide)
             shortcut.setContext(Qt.ApplicationShortcut)
-            if isinstance(func, collections.Callable):
+            if isinstance(func, collections.abc.Callable):
                 shortcut.activated.connect(func)
         if action_data:
             is_menu = action_data.get('is_menu', False)
@@ -938,7 +938,7 @@ def install_shortcuts(obj, actions, ide):
             elif keysequence and not is_menu:
                 item_ui.setShortcut(short(keysequence))
                 item_ui.setShortcutContext(Qt.ApplicationShortcut)
-            if isinstance(func, collections.Callable) and not is_menu:
+            if isinstance(func, collections.abc.Callable) and not is_menu:
                 item_ui.triggered.connect(lambda _, func=func: func())
             if section and section[0] is not None and weight:
                 ide.register_menuitem(item_ui, section, weight)


### PR DESCRIPTION
This PR contains initial fixes for modern Python (3.9 ~ 3.13),
and a few hacks for QT. This is just enough to allow Ninja to launch, create a single file, and execute it. Many more small changes are needed.

- Replace usage of `collections.Callable` with `collections.abc.Callable`.
- Cast multiple values to int to prevent QT crashes.


